### PR TITLE
feat: add box constraints for HCNN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+.vscode/
 __pycache__/
 *.py[cod]
 *$py.class

--- a/src/hcnn/constraints/base.py
+++ b/src/hcnn/constraints/base.py
@@ -1,0 +1,14 @@
+"""Abstract class for constraint sets."""
+
+from abc import abstractmethod
+
+import jax.numpy as jnp
+
+
+class Constraint:
+    """Abstract class for constraint sets."""
+
+    @abstractmethod
+    def project(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Project the input to the feasible region."""
+        pass

--- a/src/hcnn/constraints/box.py
+++ b/src/hcnn/constraints/box.py
@@ -1,0 +1,57 @@
+"""Box constraint module."""
+
+from typing import Optional
+
+from jax import numpy as jnp
+from jax.experimental import checkify
+
+from hcnn.constraints.base import Constraint
+
+
+class BoxConstraint(Constraint):
+    """Box constraint set.
+
+    The box constraint set is defined as the Cartesian product of intervals.
+    The interval is defined by a lower and an upper bound.
+    The constraint possibly act only on a subset of the dimensions,
+    defined by a mask.
+    """
+
+    def __init__(
+        self,
+        lower_bound: jnp.ndarray,
+        upper_bound: jnp.ndarray,
+        mask: Optional[jnp.ndarray] = None,
+    ):
+        """Initialize the box constraint.
+
+        Args:
+            lower_bound: Lower bound of the box.
+            upper_bound: Upper bound of the box.
+            mask: Mask to apply the constraint only to some dimensions.
+        """
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound
+        if mask is None:
+            mask = jnp.ones_like(lower_bound, dtype=jnp.bool_)
+        self.mask = mask
+
+        checkify.check(
+            lower_bound.shape == upper_bound.shape,
+            "Lower and upper bounds must have the same shape.",
+        )
+        checkify.check(
+            lower_bound.shape[0] == jnp.sum(mask),
+            "Number of active entries must be the same of the bounds.",
+        )
+        checkify.check(
+            jnp.all(lower_bound <= upper_bound),
+            "Lower bound must be less than or equal to the upper bound.",
+        )
+        checkify.check(mask.dtype == jnp.bool_, "Mask must be a boolean array.")
+
+    def project(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Project the input to the feasible region."""
+        return x.at[self.mask].set(
+            jnp.clip(x[self.mask], self.lower_bound, self.upper_bound)
+        )

--- a/src/test/test_box.py
+++ b/src/test/test_box.py
@@ -1,0 +1,65 @@
+"""Tests for the box constraint."""
+
+import jax.numpy as jnp
+
+from hcnn.constraints.box import BoxConstraint
+
+
+def test_box():
+    lower_bounds = [
+        jnp.array([0, 0]),
+        jnp.array([0, 0]),
+        jnp.array([0, 0]),
+        jnp.array([0, 0]),
+        jnp.array([-0.5, 0]),
+        jnp.array([-0.5, 0]),
+    ]
+    upper_bounds = [
+        jnp.array([1, 1]),
+        jnp.array([1, 2]),
+        jnp.array([1, 1]),
+        jnp.array([1, 1]),
+        jnp.array([0.5, 1]),
+        jnp.array([0.5, 1]),
+    ]
+    xs = [
+        jnp.array([2, 2]),
+        jnp.array([2, 2]),
+        jnp.array([0.5, 0.5]),
+        jnp.array([-0.5, -0.5]),
+        jnp.array([-0.5, 1.5]),
+        jnp.array([-1.5, 1.5]),
+    ]
+    ys = [
+        jnp.array([1, 1]),
+        jnp.array([1, 2]),
+        jnp.array([0.5, 0.5]),
+        jnp.array([0, 0]),
+        jnp.array([-0.5, 1]),
+        jnp.array([-0.5, 1]),
+    ]
+
+    for lb, ub, x, y in zip(lower_bounds, upper_bounds, xs, ys):
+        box_constraint = BoxConstraint(lb, ub)
+        z = box_constraint.project(x)
+
+        assert jnp.allclose(
+            y, z
+        ), f"""
+            Projection of {x} onto:
+                lb: {lb}
+                ub: {ub}
+            should be {y}, instead of {z}.
+        """
+
+
+def test_mask():
+    box_constraint = BoxConstraint(
+        jnp.array([0]), jnp.array([1]), jnp.array([1, 0], dtype=jnp.bool_)
+    )
+    x = jnp.array([2, 2])
+
+    y = box_constraint.project(x)
+
+    assert y[0] == 1, "The first element should be clipped to 1."
+    assert y[1] == 2, "The second element should not be clipped."


### PR DESCRIPTION
This commit:
- adds the generic constraint class `Constraint` for the HCNN.
- adds the box constraint class `BoxConstraint` for the HCNN.
- adds tests for the box constraint class, including the possibility of masked dimensions.
- includes vscode to the `.gitignore` file.