### PR TITLE
feat: add equality constraints for HCNN

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pytest==8.3.4
 optax==0.2.4
 flax==0.10.2
 snowballstemmer==2.2.0
+cvxpy==1.6.0
+matplotlib==3.10.0

--- a/src/hcnn/constraints/affine_equality.py
+++ b/src/hcnn/constraints/affine_equality.py
@@ -1,0 +1,94 @@
+"""Equality constraint module."""
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import checkify
+
+from hcnn.constraints.base import Constraint
+
+
+class EqualityConstraint(Constraint):
+    """Equality constraint set.
+
+    The (affine) equality constraint set is defined as:
+    A @ x == b
+    where the matrix A and the vector b are the parameters.
+    It might be worth to consider masking, so that the
+    constraint acts only on a subset of dimensions.
+    """
+
+    def __init__(
+        self,
+        A: jnp.ndarray,
+        b: jnp.ndarray,
+        method: str = "pinv",
+    ):
+        """Initialize the equality constraint.
+
+        Args:
+            A: Left hand side matrix.
+            b: Right hand side vector.
+            method: A string that specifies the method used to solve
+                linear systems. Valid method "pinv", "cholesky".
+        """
+        self.A = A
+        self.b = b
+
+        # Check if batch sizes are consistent.
+        # They should either be the same, or one of them should be 1.
+        checkify.check(
+            self.A.shape[0] == self.b.shape[0]
+            or self.A.shape[0] == 1
+            or self.b.shape[0] == 1,
+            f"Batch sizes are inconsistent: A{self.A.shape}, b{self.b.shape}",
+        )
+
+        checkify.check(
+            self.A.shape[1] == b.shape[1], "Number of rows in A must equal size of b."
+        )
+
+        # List of valid methods
+        valid_methods = ["pinv", "cholesky"]
+
+        # TODO: Maybe include checks on if the chosen method
+        # is applicable.
+        if method == "pinv":
+            # Compute pseudo-inverse
+            self.Apinv = jnp.linalg.pinv(self.A)
+            # Instantiate projection method
+            self.project = self.project_pinv
+        elif method == "cholesky":
+            # Compute gramian of A
+            Agram = self.A @ jnp.matrix_transpose(self.A)
+            # Compute Cholesky factorization (pretty efficient for PSD matrices)
+            cfac = jax.scipy.linalg.cho_factor(Agram, lower=False)
+            # Handling of batch dimension
+            if self.A.shape[0] == 1:
+                self.cho_solve = jax.vmap(
+                    lambda x: jax.scipy.linalg.cho_solve((cfac[0][0, :, :], False), x)
+                )
+            else:
+                self.cho_solve = lambda x: jax.scipy.linalg.cho_solve(cfac, x)
+            # Instantiate projection method
+            self.project = self.project_cholesky
+
+        else:
+            raise ValueError(
+                f"Invalid method {method}. Valid methods are: {valid_methods}"
+            )
+
+    def project_pinv(self, x: jnp.ndarray):
+        """Project onto equality constraints using pseudo-inverse.
+
+        Args:
+            x: Point to be projected. Shape (n_batch, dimension, 1)
+        """
+        return x - self.Apinv @ (self.A @ x - self.b)
+
+    def project_cholesky(self, x: jnp.ndarray):
+        """Project onto equality contraints using cholesky factorization.
+
+        Args:
+            x: Point to be projected. Shape (n_batch, dimension, 1)
+        """
+        return x - jnp.matrix_transpose(self.A) @ self.cho_solve(self.A @ x - self.b)

--- a/src/hcnn/flax_project.py
+++ b/src/hcnn/flax_project.py
@@ -18,7 +18,9 @@ class Project(nn.Module):
     def __call__(self, x: jnp.ndarray, step: int = 0) -> jnp.ndarray:
         """Project the input to the feasible region."""
         y = x
+        y = jnp.expand_dims(y, axis=2)
         for constraint in self.constraints:
             y = constraint.project(y)
         interpolation_value = self.schedule(step)
+        y = y.reshape(x.shape)
         return interpolation_value * x + (1 - interpolation_value) * y

--- a/src/test/test_equality.py
+++ b/src/test/test_equality.py
@@ -1,0 +1,155 @@
+"""Tests for the equality constraint."""
+
+from itertools import product
+
+import cvxpy as cp
+import jax
+import jax.numpy as jnp
+import pytest
+
+from hcnn.constraints.affine_equality import EqualityConstraint
+
+# Set JAX precision to 64 bits.
+jax.config.update("jax_enable_x64", True)
+
+
+# Test Parameters
+# Vector dimension
+DIM = 100
+# Random seeds
+SEEDS = [0, 24]
+# Methods for equality constraints (paired with above seeds)
+VALID_METHODS = ["pinv", "cholesky"]
+# Number of equality constraints (for QP test)
+N_EQ = 50
+# Batch size options
+N_BATCH = [1, 10]
+
+
+@pytest.mark.parametrize(
+    "method, seed, n_batch_A, n_batch_b, n_batch_x",
+    product(VALID_METHODS, SEEDS, N_BATCH, N_BATCH, N_BATCH),
+)
+def test_equality_eye(method, seed, n_batch_A, n_batch_b, n_batch_x):
+    # A and b always have smaller or equal batch size than that of x.
+    if n_batch_A > n_batch_x or n_batch_b > n_batch_x:
+        return
+    # Instantiate key
+    key = jax.random.PRNGKey(seed)
+    key = jax.random.split(key, num=2)
+    # Equality constraint
+    A = jnp.repeat(jnp.expand_dims(jnp.eye(DIM), axis=0), n_batch_A, axis=0)
+    b = jax.random.uniform(key[0], shape=(n_batch_b, DIM, 1))
+    # Point to be projected. Shape (n_batch, dimension, 1).
+    x = jax.random.uniform(key[1], shape=(n_batch_x, DIM, 1))
+    # True projection
+    y = b
+
+    # Instantiate object and project
+    eq_constraint = EqualityConstraint(A, b, method=method)
+    z = eq_constraint.project(x)
+    assert jnp.allclose(z, y)
+
+
+@pytest.mark.parametrize(
+    "method, seed, n_batch_A, n_batch_b, n_batch_x",
+    product(VALID_METHODS, SEEDS, N_BATCH, N_BATCH, N_BATCH),
+)
+def test_equality_diagonal(method, seed, n_batch_A, n_batch_b, n_batch_x):
+    # A and b always have smaller or equal batch size than that of x.
+    if n_batch_A > n_batch_x or n_batch_b > n_batch_x:
+        return
+    # Instantiate key
+    key = jax.random.PRNGKey(seed)
+    key = jax.random.split(key, num=2)
+    # Test with invertible diagonal matrix
+    A = jnp.repeat(
+        jnp.expand_dims(jnp.diag(jnp.arange(DIM) + 1), axis=0), n_batch_A, axis=0
+    )
+    b = jax.random.uniform(key[0], shape=(n_batch_b, DIM, 1))
+    x = jax.random.uniform(key[1], shape=(n_batch_x, DIM, 1))
+    # True projection
+    y = jnp.linalg.inv(A) @ b
+
+    # Instantiate object and project
+    eq_constraint = EqualityConstraint(A, b, method=method)
+    z = eq_constraint.project(x)
+    assert jnp.allclose(z, y)
+
+
+@pytest.mark.parametrize(
+    "method, seed, n_batch_A, n_batch_b, n_batch_x",
+    product(VALID_METHODS, SEEDS, N_BATCH, N_BATCH, N_BATCH),
+)
+def test_equality_generic_invertible(method, seed, n_batch_A, n_batch_b, n_batch_x):
+    # A and b always have smaller or equal batch size than that of x.
+    if n_batch_A > n_batch_x or n_batch_b > n_batch_x:
+        return
+    # Test with generic invertible matrix
+    key = jax.random.PRNGKey(seed)
+    key = jax.random.split(key, num=3)
+    # Generate random matrix
+    A = jax.random.uniform(key[0], shape=(n_batch_A, DIM, DIM))
+    # Normalize
+    A = (A @ jnp.matrix_transpose(A) + jnp.eye(DIM)) + (A - jnp.matrix_transpose(A))
+    b = jax.random.uniform(key[1], shape=(n_batch_b, DIM, 1))
+    x = jax.random.uniform(key[2], shape=(n_batch_x, DIM, 1))
+    # True projection is A^{-1} @ b (A is invertible)
+    y = jnp.linalg.solve(A, b)
+
+    # Instantiate object and project
+    eq_constraint = EqualityConstraint(A, b, method=method)
+    z = eq_constraint.project(x)
+    assert jnp.allclose(z, y)
+
+
+@pytest.mark.parametrize(
+    "method, seed, n_batch_A, n_batch_b, n_batch_x",
+    product(VALID_METHODS, SEEDS, N_BATCH, N_BATCH, N_BATCH),
+)
+def test_equality_QP(method, seed, n_batch_A, n_batch_b, n_batch_x):
+    # A and b always have smaller or equal batch size than that of x.
+    if n_batch_A > n_batch_x or n_batch_b > n_batch_x:
+        return
+    # Test with generic matrix
+    key = jax.random.PRNGKey(seed)
+    key = jax.random.split(key, num=3)
+    A = jax.random.uniform(key[0], shape=(n_batch_A, N_EQ, DIM))
+    # Generate RHS b vector
+    if n_batch_A > n_batch_b:
+        # If we have more A than b, then we need to find
+        # an element in the intersection of their ranges.
+        x_list, constraints = [], []
+        b_common = cp.Variable(N_EQ)
+        for ii in range(n_batch_A):
+            x_list.append(cp.Variable(DIM))
+            constraints += [A[ii, :, :] @ x_list[ii] == b_common]
+        # Add this constraint to keep the solution bounded
+        constraints += [-1 <= x_list[0], x_list[0] <= 1]
+        # Add some objective (not important), to avoid the trivial solution
+        objective = cp.Minimize(jnp.ones(shape=(DIM,)) @ x_list[0])
+        problem = cp.Problem(objective=objective, constraints=constraints)
+        problem.solve(verbose=False)
+        b = jnp.reshape(jnp.array(b_common.value), shape=(n_batch_b, N_EQ, 1))
+    else:
+        # If we have more b than A, then we generate b in the range of A
+        b = A @ jax.random.uniform(key[1], shape=(n_batch_b, DIM, 1))
+
+    x = jax.random.uniform(key[2], shape=(n_batch_x, DIM, 1))
+    # Vectors should have shape (dimension,). If (dimension,1) it crashes
+    # Instantiate object and project
+    eq_constraint = EqualityConstraint(A, b, method=method)
+    z = eq_constraint.project(x)
+    # Compute true projection by solving equality constrained QP
+    for ii in range(n_batch_x):
+        ycp = cp.Variable(DIM)
+        objective = cp.Minimize(cp.sum_squares(x[ii, :, 0] - ycp))
+        constraints = [
+            A[min(ii, n_batch_A - 1), :, :] @ ycp == b[min(ii, n_batch_b - 1), :, 0]
+        ]
+        problem = cp.Problem(objective=objective, constraints=constraints)
+        problem.solve()
+        # Extract true projection
+        y = jnp.expand_dims(jnp.array(ycp.value), axis=1)
+
+        assert jnp.allclose(z[ii, :], y)

--- a/src/test/test_equality_2d.py
+++ b/src/test/test_equality_2d.py
@@ -1,0 +1,143 @@
+"""Test the HardConstrainedMLP on 2d with 1 equality constraint."""
+
+from itertools import product
+from typing import List
+
+import jax
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import optax
+import pytest
+from flax import linen as nn
+from flax.training import train_state
+
+from hcnn.constraints.affine_equality import EqualityConstraint
+from hcnn.constraints.base import Constraint
+from hcnn.flax_project import Project
+
+jax.config.update("jax_enable_x64", True)
+# Random seeds
+SEEDS = [24, 42]
+# Methods for equality constraints (paired with above seeds)
+VALID_METHODS = ["pinv", "cholesky"]
+
+
+class HardConstrainedMLP(nn.Module):
+    """Simple MLP with hard constraints on the output."""
+
+    constraints: List[Constraint]
+
+    def setup(self):
+        schedule = optax.linear_schedule(0.0, 0.0, 200)
+        self.project = Project(self.constraints, schedule)
+
+    @nn.compact
+    def __call__(self, x, step):
+        x = nn.Dense(64)(x)
+        x = nn.softplus(x)
+        x = nn.Dense(64)(x)
+        x = nn.softplus(x)
+        x = nn.Dense(2)(x)
+        x = self.project(x, step)
+        return x
+
+
+@pytest.mark.parametrize("method, seed", product(VALID_METHODS, SEEDS))
+def test_equality_constraint_2d(method, seed):
+    """Test HardConstrainedMLP on a 2D fitting with equality constraints.
+
+    The problem consists in fitting a (1D) parametrization of a 2D curve.
+    The output is constrained to lie on the y=x line, i.e., one
+    equality constraint.
+    """
+    # Test parameters
+    N_SAMPLES = 2000
+    LEARNING_RATE = 5e-3
+    N_EPOCHS = 2000
+
+    # Generate dataset
+    x = jnp.linspace(0.0, 1.0, N_SAMPLES).reshape(-1, 1)
+    y = jnp.hstack((x, x + jnp.sin(1.0 * jnp.pi * x)))
+
+    # Define and initialize the hard-constrained MLP
+    # Define equality constraint LHS and RHS
+    A = jnp.expand_dims(jnp.array([[1.0, -1.0]]), axis=0)
+    b = jnp.zeros(shape=(1, 1, 1))
+    # Instantiate equality constraint
+    eq_constraint = EqualityConstraint(A=A, b=b, method=method)
+    model = HardConstrainedMLP([eq_constraint])
+    params = model.init(jax.random.PRNGKey(seed=seed), jnp.ones((1, 1)), 0)
+    tx = optax.adam(LEARNING_RATE)
+    state = train_state.TrainState.create(
+        apply_fn=model.apply, params=params["params"], tx=tx
+    )
+
+    # Train the MLP
+    @jax.jit
+    def train_step(state, x_batch, y_batch, step):
+        def loss_fn(params):
+            predictions = state.apply_fn({"params": params}, x_batch, step)
+            return jnp.mean((predictions - y_batch) ** 2)
+
+        grads = jax.grad(loss_fn)(state.params)
+        return state.apply_gradients(grads=grads)
+
+    # Run training
+    for step in range(N_EPOCHS):
+        state = train_step(state, x, y, step)
+
+    # Get predictions
+    predictions = model.apply({"params": state.params}, x, 100000)
+
+    # Project ground truth onto the y=x axis
+    projected_y = jnp.repeat(jnp.average(y, axis=1, keepdims=True), repeats=2, axis=1)
+
+    atol = 3e-2
+    rtol = 1e-3
+    assert jnp.allclose(predictions, projected_y, atol=atol, rtol=rtol)
+
+    # Plot dataset and print extra results
+    # Create a scatter plot
+    extra_results = False
+    if extra_results:
+        # Plot ground truth
+        scatter_gt = plt.scatter(y[:, 0], y[:, 1], c=x, cmap="viridis", label="GT")
+        plt.plot(y[:, 0], y[:, 1], c="blue", label="Predictions")
+
+        # Plot predictions
+        plt.scatter(
+            predictions[:, 0],
+            predictions[:, 1],
+            c=x,
+            cmap="viridis",
+            label="Predictions",
+        )
+        plt.plot(predictions[:, 0], predictions[:, 1], c="black", label="Predictions")
+
+        # Plot ground truth projected onto the y=x line
+        # Add a little offset for visual clarity
+        plotting_offset = 0.05
+        plt.scatter(
+            projected_y[:, 0] + plotting_offset,
+            projected_y[:, 1] - plotting_offset,
+            c=x,
+            cmap="viridis",
+            label="Project GT",
+        )
+        plt.plot(
+            projected_y[:, 0] + plotting_offset,
+            projected_y[:, 1] - plotting_offset,
+            c="red",
+            label="Project GT",
+        )
+
+        # Add a colorbar
+        plt.colorbar(scatter_gt, label="Parametric value x")
+
+        # Label axes
+        plt.xlabel("x-coordinate")
+        plt.ylabel("y-coordinate")
+
+        # Show plot
+        plt.axis("equal")
+        plt.show()


### PR DESCRIPTION
This commit:
- implements projection onto equality constraints
using pseudo-inverse or Cholesky factorization.
- adds tests for this projection using both methods
and considering different batch sizes for A and b.
- flax_project to handle the shape of its input.
- adds a simple 2d test for training an
equality-constrained NN.
- adds requirements for the project.

Closes https://github.com/antonioterpin/hcnn/issues/10