### PR TITLE
fix: add tests for instantiation errors

### DIFF
--- a/src/hcnn/constraints/affine_equality.py
+++ b/src/hcnn/constraints/affine_equality.py
@@ -34,6 +34,19 @@ class EqualityConstraint(Constraint):
         self.A = A
         self.b = b
 
+        checkify.check(
+            A.ndim == 3,
+            "A is a matrix with shape (n_batch, n_constraints, dimension).",
+        )
+        checkify.check(
+            b.ndim == 3,
+            "b is a matrix with shape (n_batch, n_constraints, 1).",
+        )
+        checkify.check(
+            b.shape[2] == 1,
+            "b must have shape (n_batch, n_constraints, 1).",
+        )
+
         # Check if batch sizes are consistent.
         # They should either be the same, or one of them should be 1.
         checkify.check(

--- a/src/test/test_box.py
+++ b/src/test/test_box.py
@@ -5,6 +5,40 @@ import jax.numpy as jnp
 from hcnn.constraints.box import BoxConstraint
 
 
+def test_instantiation_error():
+    try:
+        BoxConstraint(jnp.array([0]), jnp.array([1, 2]))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("The upper and lower bounds must have the same shape.")
+
+    try:
+        BoxConstraint(
+            jnp.array([0]), jnp.array([1]), jnp.array([1, 0], dtype=jnp.int32)
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("The mask must be a boolean array.")
+
+    try:
+        BoxConstraint(
+            jnp.array([0]), jnp.array([1]), jnp.array([1, 1], dtype=jnp.bool_)
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("The mask must have the same shape as the bounds.")
+
+    try:
+        BoxConstraint(jnp.array([0, 1]), jnp.array([1, 0]))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("The lower bound must be less than the upper bound.")
+
+
 def test_box():
     lower_bounds = [
         jnp.array([0, 0]),

--- a/src/test/test_equality.py
+++ b/src/test/test_equality.py
@@ -26,6 +26,49 @@ N_EQ = 50
 N_BATCH = [1, 10]
 
 
+def test_instantiation_error():
+    try:
+        EqualityConstraint(jnp.array([1]), jnp.array([[[1]]]))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(
+            "No check that A is a matrix with shape (n_batch, n_constraints, dimension)."
+        )
+
+    try:
+        EqualityConstraint(jnp.array([[[1]]]), jnp.array([[1]]))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(
+            "No check that b must have shape (n_batch, n_constraints, 1)."
+        )
+
+    try:
+        EqualityConstraint(jnp.array([[[1]]]), jnp.array([[[1, 2]]]))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(
+            "No check that b must have shape (n_batch, n_constraints, 1)."
+        )
+
+    try:
+        EqualityConstraint(jnp.array([[[1]], [[1]], [[1]]]), jnp.array([[[1]], [[1]]]))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("No check that batch sizes are consistent.")
+
+    try:
+        EqualityConstraint(jnp.array([[[1], [1], [1]]]), jnp.array([[[1]], [[1]]]))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Number of rows in A must equal size of b.")
+
+
 @pytest.mark.parametrize(
     "method, seed, n_batch_A, n_batch_b, n_batch_x",
     product(VALID_METHODS, SEEDS, N_BATCH, N_BATCH, N_BATCH),


### PR DESCRIPTION
This commit introduces tests for instantiation errors in the `Box` and `AffineEquality` constraints. By doing so, it detects a missing check in the `AffineEquality` constraint, which is fixed in this commit.