### PR TITLE
Fixed cv method AttributeError for equality-only constraints

### DIFF
--- a/src/pinet/project.py
+++ b/src/pinet/project.py
@@ -62,6 +62,7 @@ class Project:
         is_single_simple_constraint = (
             self.ineq_constraint is None and len(constraints) == 1
         )
+        self.is_single_simple_constraint = is_single_simple_constraint
 
         self.dim_lifted = self.dim
         self.step_iteration = lambda s_prev, yraw, sigma, omega: s_prev
@@ -182,6 +183,8 @@ class Project:
         Returns:
             jnp.ndarray: Constraint violation for each point in the batch.
         """
+        if self.is_single_simple_constraint:
+            return self.single_constraint.cv(y)
         if y.x.shape[1] != self.dim_lifted:
             y = self.lift(y)
         return jnp.maximum(


### PR DESCRIPTION
Fixed missing check in Project.cv that caused AttributeError when only equality constraints are provided, as lifted_eq_constraint and lifted_box_constraint are not defined in that case.