### PR TITLE
chore(typing+pytrees): adopt jaxtyping and migrate to equinox.Module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "cvxpylayers>=0.1.9",
     "jaxopt>=0.8.5",
     "wandb>=0.20.1",
+    "jaxtyping>=0.3.7",
+    "equinox>=0.13.7",
 ]
 
 # Optional dependencies
@@ -92,6 +94,8 @@ select = [
 ]
 ignore = [
     "PLR0913", # Too many arguments
+    "F722",    # Allow jaxtyping's string-shape annotations (e.g. Float[Array, "B m n"]).
+    "F821",    # Symbolic axis names inside jaxtyping strings are not module-level names.
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,11 +94,18 @@ select = [
 ]
 ignore = [
     "PLR0913", # Too many arguments
-    "F722",    # Allow jaxtyping's string-shape annotations (e.g. Float[Array, "B m n"]).
-    "F821",    # Symbolic axis names inside jaxtyping strings are not module-level names.
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# jaxtyping string-shape annotations (``Float[Array, "B m n"]``) trigger F722
+# (syntax error in forward annotation) and F821 (undefined name) because the
+# quoted axis names are not module-level symbols. Scope the ignore to the
+# library files that actually use those annotations so F722/F821 stay active
+# everywhere else (tests, benchmarks, tools).
+"src/pinet/**" = [
+    "F722",
+    "F821",
+]
 "src/test/**" = [
     "PLR2004", # Magic values are fine in tests.
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,18 @@ extend-ignore-names = [
 max-branches = 16
 max-statements = 120
 
+[tool.basedpyright]
+# equinox.Module sets fields via ``self.x = ...`` inside a custom ``__init__``;
+# calling ``super().__init__()`` is neither required nor supported by the
+# dataclass machinery that eqx.Module builds on.
+reportMissingSuperCall = false
+# Abstract constraint bases use eqx.Module's own abstract-method enforcement;
+# the implicit-Protocol diagnostic is spurious here.
+reportImplicitAbstractClass = false
+# Matrix-name identifiers (A, B, ``_A``, ...) are standard math notation across
+# the project; reassigning them in ``__init__`` is not a constant-redefinition.
+reportConstantRedefinition = false
+
 [tool.pydoclint]
 style = "google"
 # Docstring enforcement only targets the library API.

--- a/src/pinet/_typing.py
+++ b/src/pinet/_typing.py
@@ -7,6 +7,8 @@ Axis-name convention used across the library:
 * ``m``            — number of rows in an equality / inequality matrix.
 * ``n_ineq``       — number of affine-inequality rows (slack-variable count).
 * ``d_lifted``     — lifted primal dimension (``n`` + auxiliary / slack variables).
+* ``n_r`` / ``n_c`` — row / column dimensions of an unbatched equilibration
+  matrix.
 
 Each alias below names a common shape so call sites stay short and docstrings
 no longer need to carry shape/dtype prose.
@@ -23,7 +25,11 @@ BatchedIneqBound = Float[Array, "B n_ineq 1"]
 BatchedScalar = Float[Array, "B 1 1"]
 BatchedLifted = Float[Array, "B d_lifted 1"]
 
-ScalingVector = Float[Array, "B d 1"]
+# Distinct axis names for row vs column scaling — jaxtyping would otherwise
+# tie them to the same length when a function accepts both (e.g. the ADMM
+# ``_project_general`` path).
+RowScaling = Float[Array, "B m_scale 1"]
+ColScaling = Float[Array, "B n_scale 1"]
 
 Mask1D = Bool[Array, "d"]
 

--- a/src/pinet/_typing.py
+++ b/src/pinet/_typing.py
@@ -1,0 +1,35 @@
+"""Shared jaxtyping aliases for precise shape and dtype annotations.
+
+Axis-name convention used across the library:
+
+* ``B``            — batch dimension.
+* ``n``            — primal dimension (number of decision variables).
+* ``m``            — number of rows in an equality / inequality matrix.
+* ``n_ineq``       — number of affine-inequality rows (slack-variable count).
+* ``d_lifted``     — lifted primal dimension (``n`` + auxiliary / slack variables).
+
+Each alias below names a common shape so call sites stay short and docstrings
+no longer need to carry shape/dtype prose.
+"""
+
+from jaxtyping import Array, Bool, Float
+
+BatchedPrimal = Float[Array, "B n 1"]
+BatchedRHS = Float[Array, "B m 1"]
+BatchedEqMatrix = Float[Array, "B m n"]
+BatchedEqPinv = Float[Array, "B n m"]
+BatchedIneqMatrix = Float[Array, "B n_ineq n"]
+BatchedIneqBound = Float[Array, "B n_ineq 1"]
+BatchedScalar = Float[Array, "B 1 1"]
+BatchedLifted = Float[Array, "B d_lifted 1"]
+
+ScalingVector = Float[Array, "B d 1"]
+
+Mask1D = Bool[Array, "d"]
+
+Matrix2D = Float[Array, "n_r n_c"]
+Vector1D = Float[Array, "d"]
+
+NLMatrix = Float[Array, "1 m n"]
+NLScalarRHS = Float[Array, "B 1 1"]
+NLLinearRHS = Float[Array, "1 1 n"]

--- a/src/pinet/constraints/affine_equality.py
+++ b/src/pinet/constraints/affine_equality.py
@@ -1,10 +1,15 @@
 """Equality constraint module."""
 
+import equinox as eqx
 import jax.numpy as jnp
 
+from pinet._typing import BatchedEqMatrix, BatchedEqPinv, BatchedRHS, BatchedScalar
 from pinet.dataclasses import ProjectionInstance
 
 from .base import Constraint
+
+_EXPECTED_NDIM = 3
+_LAST_AXIS_SIZE_B = 1
 
 
 class EqualityConstraint(Constraint):
@@ -13,14 +18,27 @@ class EqualityConstraint(Constraint):
     The (affine) equality constraint set is defined as:
     a_dyn @ x == b
     where the matrix a_dyn and the vector b are the parameters.
-    It might be worth to consider masking, so that the
-    constraint acts only on a subset of dimensions.
+
+    Attributes:
+        a_dyn: Left-hand side matrix.
+        b: Right-hand side vector.
+        a_dyn_pinv: Pseudoinverse of ``a_dyn`` (cached when ``var_a_dyn`` is False).
+        method: Solver strategy; ``"pinv"`` or ``None``.
+        var_b: Whether ``b`` is expected to vary per instance.
+        var_a_dyn: Whether ``a_dyn`` is expected to vary per instance.
     """
+
+    a_dyn: BatchedEqMatrix
+    b: BatchedRHS
+    a_dyn_pinv: BatchedEqPinv | None = None
+    method: str | None = eqx.field(static=True, default="pinv")
+    var_b: bool | None = eqx.field(static=True, default=False)
+    var_a_dyn: bool | None = eqx.field(static=True, default=False)
 
     def __init__(
         self,
-        a_dyn: jnp.ndarray,
-        b: jnp.ndarray,
+        a_dyn: BatchedEqMatrix,
+        b: BatchedRHS,
         method: str | None = "pinv",
         var_b: bool | None = False,
         var_a_dyn: bool | None = False,
@@ -29,9 +47,7 @@ class EqualityConstraint(Constraint):
 
         Args:
             a_dyn: Left hand side matrix.
-                Shape (batch_size, n_constraints, dimension).
             b: Right hand side vector.
-                Shape (batch_size, n_constraints, 1).
             method: String that specifies the method used to solve
                 linear systems. Valid methods are "pinv", and None.
             var_b: Boolean that indicates whether the b vector
@@ -44,94 +60,77 @@ class EqualityConstraint(Constraint):
         # The equality constraint always needs its right-hand side vector.
         assert b is not None, "Vector b must be provided."
 
+        # The equality matrix is batched as (batch_size, n_constraints, dimension).
+        assert a_dyn.ndim == _EXPECTED_NDIM, (
+            "a_dyn is a matrix with shape (batch_size, n_constraints, dimension)."
+        )
+        # The right-hand side is batched with the same rank as a_dyn.
+        assert b.ndim == _EXPECTED_NDIM, (
+            "b is a matrix with shape (batch_size, n_constraints, 1)."
+        )
+        # The last axis of b stores a single scalar per constraint.
+        assert b.shape[2] == _LAST_AXIS_SIZE_B, (
+            "b must have shape (batch_size, n_constraints, 1)."
+        )
+        # Batch sizes must be the same, or one of them must be 1.
+        assert a_dyn.shape[0] == b.shape[0] or a_dyn.shape[0] == 1 or b.shape[0] == 1, (
+            f"Batch sizes are inconsistent: a_dyn{a_dyn.shape}, b{b.shape}"
+        )
+        # Each equality row in a_dyn needs one matching entry in b.
+        assert a_dyn.shape[1] == b.shape[1], (
+            "Number of rows in a_dyn must equal size of b."
+        )
+
+        valid_methods = ["pinv", None]
+        if method not in valid_methods:
+            raise ValueError(
+                f"Invalid method {method}. Valid methods are: {valid_methods}"
+            )
+
+        a_dyn_pinv: BatchedEqPinv | None = None
+        if method == "pinv" and not var_a_dyn:
+            a_dyn_pinv = jnp.linalg.pinv(a_dyn)
+
         self.a_dyn = a_dyn
         self.b = b
+        self.a_dyn_pinv = a_dyn_pinv
         self.method = method
         self.var_b = var_b
         self.var_a_dyn = var_a_dyn
 
-        self.EXPECTED_NDIM = 3
-        self.LAST_AXIS_SIZE_B = 1
-
-        self.setup()
-
-    def setup(self) -> None:
-        """Sets up the equality constraint.
-
-        Raises:
-            Exception: If the provided method is not valid.
-        """
-
-        # The equality matrix is batched as (batch_size, n_constraints, dimension).
-        assert self.a_dyn.ndim == self.EXPECTED_NDIM, (
-            "a_dyn is a matrix with shape (batch_size, n_constraints, dimension)."
-        )
-        # The right-hand side is batched with the same rank as a_dyn.
-        assert self.b.ndim == self.EXPECTED_NDIM, (
-            "b is a matrix with shape (batch_size, n_constraints, 1)."
-        )
-        # The last axis of b stores a single scalar per constraint.
-        assert self.b.shape[2] == self.LAST_AXIS_SIZE_B, (
-            "b must have shape (batch_size, n_constraints, 1)."
-        )
-
-        # Check if batch sizes are consistent.
-        # They should either be the same, or one of them should be 1.
-        # a_dyn and b must be batch-compatible, allowing singleton broadcasting.
-        assert (
-            self.a_dyn.shape[0] == self.b.shape[0]
-            or self.a_dyn.shape[0] == 1
-            or self.b.shape[0] == 1
-        ), f"Batch sizes are inconsistent: a_dyn{self.a_dyn.shape}, b{self.b.shape}"
-
-        # Each equality row in a_dyn needs one matching entry in b.
-        assert self.a_dyn.shape[1] == self.b.shape[1], (
-            "Number of rows in a_dyn must equal size of b."
-        )
-
-        # List of valid methods
-        valid_methods = ["pinv", None]
-
-        if self.method == "pinv":
-            if not self.var_a_dyn:
-                self.a_dyn_pinv = jnp.linalg.pinv(self.a_dyn)
-
-            self.project = self.project_pinv
-        elif self.method is None:
-
-            def raise_not_implemented_error(
-                yraw: ProjectionInstance,
-            ) -> ProjectionInstance:
-                raise NotImplementedError("No projection method set.")
-
-            self.project = raise_not_implemented_error
-        else:
-            raise Exception(
-                f"Invalid method {self.method}. Valid methods are: {valid_methods}"
-            )
-
     def get_params(
         self, inp: ProjectionInstance
-    ) -> tuple[jnp.ndarray, jnp.ndarray | None, jnp.ndarray | None]:
+    ) -> tuple[BatchedRHS, BatchedEqMatrix | None, BatchedEqPinv | None]:
         """Get matrix, b, matrix_pinv depending on varying constraints.
 
         Args:
             inp: ProjectionInstance to get parameters from.
 
         Returns:
-            tuple Tuple containing
-                b: Right hand side vector.
-                    Shape (batch_size, n_constraints, 1).
-                matrix: Left hand side matrix.
-                    Shape (batch_size, n_constraints, dimension).
-                matrix_pinv: Pseudo-inverse of matrix.
-                    Shape (batch_size, n_constraints, dimension).
+            Tuple ``(b, matrix, matrix_pinv)`` with the right-hand side vector,
+            the left-hand side matrix and its pseudo-inverse, respectively.
         """
         b = inp.eq.b if inp.eq and inp.eq.b is not None else self.b
         a_dyn = inp.eq.a_dyn if inp.eq and self.var_a_dyn else self.a_dyn
         a_dyn_pinv = inp.eq.a_dyn_pinv if inp.eq and self.var_a_dyn else self.a_dyn_pinv
-
         return b, a_dyn, a_dyn_pinv
+
+    def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
+        """Project onto equality constraints.
+
+        Args:
+            yraw: ProjectionInstance to projection.
+                The .x attribute is the point to project.
+
+        Returns:
+            The projected point for each point in the batch.
+
+        Raises:
+            NotImplementedError: If ``method`` is ``None``.
+        """
+        if self.method is None:
+            raise NotImplementedError("No projection method set.")
+        return self.project_pinv(yraw)
 
     def project_pinv(self, yraw: ProjectionInstance) -> ProjectionInstance:
         """Project onto equality constraints using pseudo-inverse.
@@ -141,7 +140,7 @@ class EqualityConstraint(Constraint):
                 The .x attribute is the point to project.
 
         Returns:
-            ProjectionInstance: The projected point for each point in the batch.
+            The projected point for each point in the batch.
         """
         b, a_dyn, a_dyn_pinv = self.get_params(yraw)
         # a_dyn must be available to apply the projection.
@@ -164,15 +163,14 @@ class EqualityConstraint(Constraint):
         """Return the number of constraints."""
         return self.a_dyn.shape[1]
 
-    def cv(self, yraw: ProjectionInstance) -> jnp.ndarray:
+    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
             yraw: ProjectionInstance to evaluate.
 
         Returns:
-            jnp.ndarray: The constraint violation for each point in the batch.
-                Shape    (batch_size, 1, 1).
+            The constraint violation for each point in the batch.
         """
         b, a_dyn, _ = self.get_params(yraw)
         # a_dyn must be available to compute the violation.

--- a/src/pinet/constraints/affine_inequality.py
+++ b/src/pinet/constraints/affine_inequality.py
@@ -2,6 +2,7 @@
 
 from jax import numpy as jnp
 
+from pinet._typing import BatchedIneqBound, BatchedIneqMatrix, BatchedScalar
 from pinet.dataclasses import ProjectionInstance
 
 from .base import Constraint
@@ -13,57 +14,61 @@ class AffineInequalityConstraint(Constraint):
     The (affine) inequality constraint set is defined as:
     lb <= constr_matrix @ x <= ub
     where the constraint matrix and the vectors lb and ub are the parameters.
+
+    Attributes:
+        constr_matrix: Matrix in the inequality.
+        lb: Lower bound.
+        ub: Upper bound.
     """
 
+    constr_matrix: BatchedIneqMatrix
+    lb: BatchedIneqBound
+    ub: BatchedIneqBound
+
     def __init__(
-        self, constr_matrix: jnp.ndarray, lb: jnp.ndarray, ub: jnp.ndarray
+        self,
+        constr_matrix: BatchedIneqMatrix,
+        lb: BatchedIneqBound,
+        ub: BatchedIneqBound,
     ) -> None:
         """Initialize the affine inequality constraint.
 
         Args:
             constr_matrix: The matrix in the inequality.
-                Shape (batch_size, n_constraints, dimension).
             lb: The lower bound in the inequality.
-                Shape (batch_size, n_constraints, 1).
             ub: The upper bound in the inequality.
-                Shape (batch_size, n_constraints, 1).
         """
-        self.constr_matrix = constr_matrix
-        self.lb = lb
-        self.ub = ub
-
-        # Check if batch sizes for constr_matrix and l are consistent.
-        # They should either be the same, or one of them should be 1.
-        # constr_matrix and lb must be batch-compatible, allowing singleton broadcasting.
+        # Batch sizes must be the same, or one of them must be 1.
         assert (
-            self.constr_matrix.shape[0] == self.lb.shape[0]
-            or self.constr_matrix.shape[0] == 1
-            or self.lb.shape[0] == 1
+            constr_matrix.shape[0] == lb.shape[0]
+            or constr_matrix.shape[0] == 1
+            or lb.shape[0] == 1
         ), (
             "Batch sizes are inconsistent: "
-            f"constr_matrix{self.constr_matrix.shape}, l{self.lb.shape}"
+            f"constr_matrix{constr_matrix.shape}, l{lb.shape}"
         )
 
-        # Check if batch sizes for constr_matrix and u are consistent.
-        # They should either be the same, or one of them should be 1.
-        # constr_matrix and ub must be batch-compatible, allowing singleton broadcasting.
         assert (
-            self.constr_matrix.shape[0] == self.ub.shape[0]
-            or self.constr_matrix.shape[0] == 1
-            or self.ub.shape[0] == 1
+            constr_matrix.shape[0] == ub.shape[0]
+            or constr_matrix.shape[0] == 1
+            or ub.shape[0] == 1
         ), (
             "Batch sizes are inconsistent: "
-            f"constr_matrix{self.constr_matrix.shape}, ub{self.ub.shape}"
+            f"constr_matrix{constr_matrix.shape}, ub{ub.shape}"
         )
 
         # Each inequality row needs one lower bound entry.
-        assert self.constr_matrix.shape[1] == self.lb.shape[1], (
+        assert constr_matrix.shape[1] == lb.shape[1], (
             "Number of rows in constr_matrix must equal size of l."
         )
         # Each inequality row needs one upper bound entry.
-        assert self.constr_matrix.shape[1] == self.ub.shape[1], (
+        assert constr_matrix.shape[1] == ub.shape[1], (
             "Number of rows in constr_matrix must equal size of u."
         )
+
+        self.constr_matrix = constr_matrix
+        self.lb = lb
+        self.ub = ub
 
     def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
         """Project x onto the affine inequality constraint set.
@@ -73,8 +78,7 @@ class AffineInequalityConstraint(Constraint):
                 The .x attribute is the point to project.
 
         Returns:
-            ProjectionInstance: The projected point for each point in the batch.
-                Shape (batch_size, dimension, 1).
+            The projected point for each point in the batch.
 
         Raises:
             NotImplementedError: Always. This method must not be called directly.
@@ -93,15 +97,14 @@ class AffineInequalityConstraint(Constraint):
         """Return the number of constraints."""
         return self.constr_matrix.shape[1]
 
-    def cv(self, yraw: ProjectionInstance) -> jnp.ndarray:
+    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
             yraw: ProjectionInstance to evaluate.
 
         Returns:
-            jnp.ndarray: The constraint violation for each point in the batch.
-                Shape (batch_size, 1, 1).
+            The constraint violation for each point in the batch.
         """
         constr_matrix_x = self.constr_matrix @ yraw.x
         cv_ub = jnp.maximum(constr_matrix_x - self.ub, 0)

--- a/src/pinet/constraints/base.py
+++ b/src/pinet/constraints/base.py
@@ -1,7 +1,5 @@
 """Abstract class for constraint sets."""
 
-from abc import abstractmethod
-
 import equinox as eqx
 
 from pinet._typing import BatchedScalar
@@ -11,10 +9,12 @@ from pinet.dataclasses import ProjectionInstance
 class Constraint(eqx.Module):
     """Abstract class for constraint sets.
 
-    Subclasses must implement ``project``, ``cv``, ``dim`` and ``n_constraints``.
+    Subclasses must override ``project``, ``cv``, ``dim`` and ``n_constraints``.
+    The base implementations raise ``NotImplementedError`` — ``@abstractmethod``
+    alone is not runtime-enforced on ``eqx.Module`` because it does not use
+    ``ABCMeta`` as its metaclass.
     """
 
-    @abstractmethod
     def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
         """Project the input to the feasible region.
 
@@ -23,9 +23,14 @@ class Constraint(eqx.Module):
 
         Returns:
             The projected input.
-        """
 
-    @abstractmethod
+        Raises:
+            NotImplementedError: Always; subclasses must override.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.project must be implemented by a subclass."
+        )
+
     def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
@@ -34,14 +39,32 @@ class Constraint(eqx.Module):
 
         Returns:
             The constraint violation for each point in the batch.
+
+        Raises:
+            NotImplementedError: Always; subclasses must override.
         """
+        raise NotImplementedError(
+            f"{type(self).__name__}.cv must be implemented by a subclass."
+        )
 
     @property
-    @abstractmethod
     def dim(self) -> int:
-        """Return the dimension of the constraint set."""
+        """Return the dimension of the constraint set.
+
+        Raises:
+            NotImplementedError: Always; subclasses must override.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.dim must be implemented by a subclass."
+        )
 
     @property
-    @abstractmethod
     def n_constraints(self) -> int:
-        """Return the number of constraints."""
+        """Return the number of constraints.
+
+        Raises:
+            NotImplementedError: Always; subclasses must override.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.n_constraints must be implemented by a subclass."
+        )

--- a/src/pinet/constraints/base.py
+++ b/src/pinet/constraints/base.py
@@ -2,13 +2,17 @@
 
 from abc import abstractmethod
 
-import jax.numpy as jnp
+import equinox as eqx
 
+from pinet._typing import BatchedScalar
 from pinet.dataclasses import ProjectionInstance
 
 
-class Constraint:
-    """Abstract class for constraint sets."""
+class Constraint(eqx.Module):
+    """Abstract class for constraint sets.
+
+    Subclasses must implement ``project``, ``cv``, ``dim`` and ``n_constraints``.
+    """
 
     @abstractmethod
     def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
@@ -18,35 +22,26 @@ class Constraint:
             yraw: ProjectionInstance to project.
 
         Returns:
-            ProjectionInstance: The projected input.
+            The projected input.
         """
 
     @abstractmethod
-    def cv(self, yraw: ProjectionInstance) -> jnp.ndarray:
+    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
             yraw: ProjectionInstance to evaluate.
 
         Returns:
-            jnp.ndarray: The constraint violation for each point in the batch.
-                Shape (batch_size, 1, 1).
+            The constraint violation for each point in the batch.
         """
 
     @property
     @abstractmethod
     def dim(self) -> int:
-        """Return the dimension of the constraint set.
-
-        Returns:
-            int: The dimension of the constraint set.
-        """
+        """Return the dimension of the constraint set."""
 
     @property
     @abstractmethod
     def n_constraints(self) -> int:
-        """Return the number of constraints.
-
-        Returns:
-            int: The number of constraints.
-        """
+        """Return the number of constraints."""

--- a/src/pinet/constraints/box.py
+++ b/src/pinet/constraints/box.py
@@ -4,7 +4,7 @@ import equinox as eqx
 import numpy as np
 from jax import numpy as jnp
 
-from pinet._typing import BatchedRHS, BatchedScalar, Mask1D, ScalingVector
+from pinet._typing import BatchedRHS, BatchedScalar, ColScaling, Mask1D
 from pinet.dataclasses import BoxConstraintSpecification, ProjectionInstance
 
 from .base import Constraint
@@ -28,14 +28,14 @@ class BoxConstraint(Constraint):
     lb: BatchedRHS | None
     ub: BatchedRHS | None
     mask: Mask1D
-    scale: ScalingVector
+    scale: ColScaling
     _dim: int = eqx.field(static=True)
     _n_constraints: int = eqx.field(static=True)
 
     def __init__(
         self,
         box_spec: BoxConstraintSpecification,
-        scale: ScalingVector | None = None,
+        scale: ColScaling | None = None,
     ) -> None:
         """Initialize the box constraint.
 
@@ -71,7 +71,11 @@ class BoxConstraint(Constraint):
             if mask is not None
             else jnp.asarray(np.ones(shape=(dim,), dtype=jnp.bool_))
         )
-        self.scale = scale if scale is not None else jnp.ones((1, dim, 1))
+        # Default scale is applied to per-instance bounds supplied via
+        # ``yraw.box.lb/ub``, which have shape ``(batch, n_constraints, 1)``.
+        # Using ``dim`` here would broadcast-error whenever ``mask`` is set
+        # (``dim != n_constraints``).
+        self.scale = scale if scale is not None else jnp.ones((1, n_constraints, 1))
         self._dim = dim
         self._n_constraints = n_constraints
 

--- a/src/pinet/constraints/box.py
+++ b/src/pinet/constraints/box.py
@@ -1,8 +1,10 @@
 """Box constraint module."""
 
+import equinox as eqx
 import numpy as np
 from jax import numpy as jnp
 
+from pinet._typing import BatchedRHS, BatchedScalar, Mask1D, ScalingVector
 from pinet.dataclasses import BoxConstraintSpecification, ProjectionInstance
 
 from .base import Constraint
@@ -15,54 +17,74 @@ class BoxConstraint(Constraint):
     The interval is defined by a lower and an upper bound.
     The constraint possibly acts only on a subset of the dimensions,
     defined by a mask.
+
+    Attributes:
+        lb: Lower bound for each constrained coordinate.
+        ub: Upper bound for each constrained coordinate.
+        mask: Boolean mask selecting which dimensions are constrained.
+        scale: Scaling vector applied to variable bounds passed via ``yraw.box``.
     """
+
+    lb: BatchedRHS | None
+    ub: BatchedRHS | None
+    mask: Mask1D
+    scale: ScalingVector
+    _dim: int = eqx.field(static=True)
+    _n_constraints: int = eqx.field(static=True)
 
     def __init__(
         self,
         box_spec: BoxConstraintSpecification,
+        scale: ScalingVector | None = None,
     ) -> None:
         """Initialize the box constraint.
 
         Args:
             box_spec: Specification of the box constraint.
                 For variable bounds, provide an example of the bounds.
+            scale: Optional scaling vector applied to variable bounds passed via
+                ``yraw.box``. Defaults to all ones.
         """
-        self.lb: jnp.ndarray | None = box_spec.lb
-        self.ub: jnp.ndarray | None = box_spec.ub
+        lb = box_spec.lb
+        ub = box_spec.ub
         mask = box_spec.mask
         if mask is not None:
-            self._dim = int(mask.size)
-        elif self.lb is not None:
-            self._dim = self.lb.shape[1]
+            dim = int(mask.size)
+        elif lb is not None:
+            dim = lb.shape[1]
         else:
             # Either lb or ub must be provided if mask is not set.
-            assert self.ub is not None
-            self._dim = self.ub.shape[1]
-        self.scale = jnp.ones((1, self._dim, 1))
+            assert ub is not None
+            dim = ub.shape[1]
 
-        if self.lb is not None:
-            self._n_constraints = self.lb.shape[1]
+        if lb is not None:
+            n_constraints = lb.shape[1]
         else:
             # At least one of lb or ub must be provided.
-            assert self.ub is not None
-            self._n_constraints = self.ub.shape[1]
-        self.mask: jnp.ndarray = (
+            assert ub is not None
+            n_constraints = ub.shape[1]
+
+        self.lb = lb
+        self.ub = ub
+        self.mask = (
             mask
             if mask is not None
-            else jnp.asarray(np.ones(shape=(self._dim,), dtype=jnp.bool_))
+            else jnp.asarray(np.ones(shape=(dim,), dtype=jnp.bool_))
         )
+        self.scale = scale if scale is not None else jnp.ones((1, dim, 1))
+        self._dim = dim
+        self._n_constraints = n_constraints
 
     def get_params(
         self, yraw: ProjectionInstance
-    ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    ) -> tuple[BatchedRHS, BatchedRHS, Mask1D]:
         """Get the parameters of the box constraint.
 
         Args:
             yraw: ProjectionInstance to get the parameters from.
 
         Returns:
-            tuple: A tuple containing the lower and upper bounds and the mask.
-                Each of shape (batch_size, n_constraints, 1).
+            A tuple ``(lb, ub, mask)`` with the lower/upper bounds and the mask.
         """
         lb = (
             (yraw.box.lb * self.scale)
@@ -83,7 +105,6 @@ class BoxConstraint(Constraint):
             ub = jnp.inf * jnp.ones_like(lb)
         # A mask is always required to know which coordinates are clipped.
         assert mask is not None
-        # NOTE: Mask is never None
 
         return lb, ub, mask
 
@@ -95,23 +116,21 @@ class BoxConstraint(Constraint):
                 The .x attribute is the point to project.
 
         Returns:
-            ProjectionInstance: The projected point for each point in the batch.
-                .x of shape (batch_size, dimension, 1).
+            The projected point for each point in the batch.
         """
         lb, ub, mask = self.get_params(yraw)
         return yraw.update(
             x=yraw.x.at[:, mask, :].set(jnp.clip(yraw.x[:, mask, :], lb, ub))
         )
 
-    def cv(self, yraw: ProjectionInstance) -> jnp.ndarray:
+    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
             yraw: ProjectionInstance to evaluate.
 
         Returns:
-            jnp.ndarray: The constraint violation for each point in the batch.
-                Shape (batch_size, 1, 1).
+            The constraint violation for each point in the batch.
         """
         lb, ub, mask = self.get_params(yraw)
         cvs = jnp.maximum(
@@ -122,18 +141,10 @@ class BoxConstraint(Constraint):
 
     @property
     def dim(self) -> int:
-        """Return the dimension of the constraint set.
-
-        Returns:
-            int: The dimension of the constraint set.
-        """
+        """Return the dimension of the constraint set."""
         return self._dim
 
     @property
     def n_constraints(self) -> int:
-        """Return the number of constraints.
-
-        Returns:
-            int: The number of constraints.
-        """
+        """Return the number of constraints."""
         return self._n_constraints

--- a/src/pinet/constraints/cartesian_constraint.py
+++ b/src/pinet/constraints/cartesian_constraint.py
@@ -1,8 +1,10 @@
 """Cartesian constraint module for combining Box and SOC constraints."""
 
+import equinox as eqx
 import jax.numpy as jnp
 
-from pinet.dataclasses import ProjectionInstance, SocConstraintSpecification
+from pinet._typing import BatchedScalar
+from pinet.dataclasses import ProjectionInstance
 
 from .base import Constraint
 from .box import BoxConstraint
@@ -14,7 +16,17 @@ class CartesianConstraint(Constraint):
 
     This class combines multiple Box and SOC constraints that act on disjoint
     subsets of the variables (non-overlapping masks).
+
+    Attributes:
+        box_constraint: Optional box component of the Cartesian product.
+        nl_constraints: SOC components.
+        n_nonlinear: Number of non-linear (SOC) constituent constraints.
     """
+
+    box_constraint: BoxConstraint | None
+    nl_constraints: list[SocConstraint]
+    _dim: int = eqx.field(static=True)
+    n_nonlinear: int = eqx.field(static=True)
 
     def __init__(
         self,
@@ -34,60 +46,52 @@ class CartesianConstraint(Constraint):
                 or if constraint dimensions are inconsistent.
             TypeError: If nl_constraints is not a list or tuple.
         """
-        self.box_constraint = box_constraint
-
         if nl_constraints is None:
-            self.nl_constraints = []
+            nls: list[SocConstraint] = []
         elif isinstance(nl_constraints, (list, tuple)):
-            self.nl_constraints = list(nl_constraints)
+            nls = list(nl_constraints)
         else:
             raise TypeError(
                 f"nl_constraints must be a list or tuple, "
                 f"got {type(nl_constraints).__name__}."
             )
 
-        self.constraints = [
-            c for c in (box_constraint, *self.nl_constraints) if c is not None
-        ]
+        self.box_constraint = box_constraint
+        self.nl_constraints = nls
+        self.n_nonlinear = len(nls)
+        self._dim = self._validate_constraints(box_constraint, nls)
 
-        self._validate_constraints()
-
-        self.n_nonlinear = len(self.nl_constraints)
-
-        # These update functions should not change
-        # the nl attribute of yraw!
-        self.update_fns = []
-
-        # Define update functions
-        def soc_update(
-            yraw: ProjectionInstance, socspec: SocConstraintSpecification
-        ) -> ProjectionInstance:
-            return yraw.update(soc=socspec)
-
-        for _ in self.nl_constraints:
-            # Placeholder for more constraints
-            # if isinstance(constraint, SocConstraint):
-            self.update_fns.append(soc_update)
-
-    def _validate_constraints(self) -> None:
+    @staticmethod
+    def _validate_constraints(
+        box_constraint: BoxConstraint | None,
+        nl_constraints: list[SocConstraint],
+    ) -> int:
         """Validate constraint types, dimensions, and mask overlap.
+
+        Args:
+            box_constraint: The optional box component.
+            nl_constraints: The list of non-linear SOC components.
+
+        Returns:
+            The shared dimension across all constraints.
 
         Raises:
             ValueError: If no constraints are provided, if constraint types are
                 invalid, if dimensions are inconsistent, or if masks overlap.
         """
-        if not self.constraints:
+        constraints: list[Constraint] = [
+            c for c in (box_constraint, *nl_constraints) if c is not None
+        ]
+        if not constraints:
             raise ValueError("At least one constraint must be provided.")
 
         # Check that the constraints are boxes and socs
-        if self.box_constraint is not None and not isinstance(
-            self.box_constraint, BoxConstraint
-        ):
+        if box_constraint is not None and not isinstance(box_constraint, BoxConstraint):
             raise ValueError(
                 f"The box_constraint must be a BoxConstraint, "
-                f"got {type(self.box_constraint).__name__}."
+                f"got {type(box_constraint).__name__}."
             )
-        for constraint in self.nl_constraints:
+        for constraint in nl_constraints:
             if not isinstance(constraint, SocConstraint):
                 raise ValueError(
                     f"Only SocConstraint is currently supported "
@@ -95,30 +99,38 @@ class CartesianConstraint(Constraint):
                 )
 
         # Validate that all constraints have the same dimension
-        self._dim = self.constraints[0].dim
-        for constraint in self.constraints:
-            if constraint.dim != self._dim:
+        dim = constraints[0].dim
+        for constraint in constraints:
+            if constraint.dim != dim:
                 raise ValueError(
                     f"All constraints must have the same dimension. "
-                    f"Expected {self._dim}, got {constraint.dim}."
+                    f"Expected {dim}, got {constraint.dim}."
                 )
 
         # Create a mask to track which dimensions are already used
-        used_mask = jnp.zeros(self._dim, dtype=bool)
+        used_mask = jnp.zeros(dim, dtype=bool)
 
-        for constraint in self.constraints:
+        for constraint in constraints:
             if isinstance(constraint, BoxConstraint):
                 # BoxConstraint.__init__ ensures mask is set.
                 assert constraint.mask is not None
                 new_mask = jnp.asarray(constraint.mask)
             else:
-                # SOC constraints have both mask_u and mask_t
+                # Narrow to SocConstraint so mask_u/mask_t are visible.
+                assert isinstance(constraint, SocConstraint)
                 new_mask = jnp.logical_or(constraint.mask_u, constraint.mask_t)
             if jnp.any(jnp.logical_and(used_mask, new_mask)):
                 raise ValueError(
                     "Constraint masks overlap with previously defined constraints."
                 )
             used_mask = jnp.logical_or(used_mask, new_mask)
+
+        return dim
+
+    @property
+    def constraints(self) -> list[Constraint]:
+        """Return all constituent constraints in order."""
+        return [c for c in (self.box_constraint, *self.nl_constraints) if c is not None]
 
     def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
         """Project the input to the feasible region.
@@ -130,7 +142,7 @@ class CartesianConstraint(Constraint):
             yraw: ProjectionInstance to project.
 
         Returns:
-            ProjectionInstance: The projected input.
+            The projected input.
         """
         if self.nl_constraints and not isinstance(yraw.nl, (list, tuple)):
             raise TypeError(
@@ -140,19 +152,16 @@ class CartesianConstraint(Constraint):
         if self.box_constraint is not None:
             yraw = self.box_constraint.project(yraw)
 
-        # Project onto each constraint
         if self.nl_constraints:
             # Narrowed by the isinstance check above.
             assert yraw.nl is not None
-            for nl_constraint, update_fn, nl_spec in zip(
-                self.nl_constraints, self.update_fns, yraw.nl, strict=True
-            ):
-                yraw = update_fn(yraw, nl_spec.to_primitive_spec())
+            for nl_constraint, nl_spec in zip(self.nl_constraints, yraw.nl, strict=True):
+                yraw = yraw.update(soc=nl_spec.to_primitive_spec())
                 yraw = nl_constraint.project(yraw)
 
         return yraw
 
-    def cv(self, yraw: ProjectionInstance) -> jnp.ndarray:
+    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Returns the maximum constraint violation across all constraints.
@@ -161,39 +170,30 @@ class CartesianConstraint(Constraint):
             yraw: ProjectionInstance to evaluate.
 
         Returns:
-            jnp.ndarray: The constraint violation for each point in the batch.
-                Shape (batch_size, 1, 1).
+            The constraint violation for each point in the batch.
         """
         cvs = []
 
         if self.box_constraint is not None:
             cvs.append(self.box_constraint.cv(yraw).reshape(-1))
 
-        # Compute constraint violations for nl constraints
         if self.nl_constraints:
             # cv requires per-instance SOC specs to be supplied on the input.
             assert yraw.nl is not None, (
                 "yraw.nl must be provided when non-linear constraints are present."
             )
-            for constraint, update_fn, nl_spec in zip(
-                self.nl_constraints, self.update_fns, yraw.nl, strict=True
-            ):
-                yraw = update_fn(yraw, nl_spec.to_primitive_spec())
+            for constraint, nl_spec in zip(self.nl_constraints, yraw.nl, strict=True):
+                yraw = yraw.update(soc=nl_spec.to_primitive_spec())
                 cvs.append(constraint.cv(yraw).reshape(-1))
 
         # Return the maximum violation
         if len(cvs) == 1:
             return cvs[0].reshape(-1, 1, 1)
-        else:
-            return jnp.max(jnp.array(cvs), 0).reshape(-1, 1, 1)
+        return jnp.max(jnp.array(cvs), 0).reshape(-1, 1, 1)
 
     @property
     def dim(self) -> int:
-        """Return the dimension of the constraint set.
-
-        Returns:
-            int: The dimension of the constraint set.
-        """
+        """Return the dimension of the constraint set."""
         return self._dim
 
     @property
@@ -201,9 +201,6 @@ class CartesianConstraint(Constraint):
         """Return the total number of constraints.
 
         Sums up the number of constraints from all constituent constraints.
-
-        Returns:
-            int: The total number of constraints.
         """
         total = 0
         for constraint in self.constraints:

--- a/src/pinet/constraints/constraint_parser.py
+++ b/src/pinet/constraints/constraint_parser.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 
+import jax
 import jax.numpy as jnp
 
 from pinet.dataclasses import (
@@ -325,7 +326,7 @@ class ConstraintParser:
         # Precondition: eq_constraint is set by __init__ for non-identity mode.
         assert eq_constraint is not None
 
-        all_matrices: list[jnp.ndarray] = [eq_constraint.a_dyn]
+        all_matrices: list[jax.Array] = [eq_constraint.a_dyn]
         dims: list[int] = [eq_constraint.dim]
         if self.ineq_constraint is not None:
             all_matrices.append(self.ineq_constraint.constr_matrix)

--- a/src/pinet/constraints/non_linear.py
+++ b/src/pinet/constraints/non_linear.py
@@ -1,10 +1,11 @@
 """Abstract class for non-linear constraints."""
 
-import jax.numpy as jnp
+import equinox as eqx
 
+from pinet._typing import BatchedRHS, BatchedScalar, NLLinearRHS, NLMatrix
 from pinet.constraints.base import Constraint
 from pinet.constraints.non_linear_types import NonLinearConstraintType
-from pinet.dataclasses import NonLinearSpecification
+from pinet.dataclasses import NonLinearSpecification, ProjectionInstance
 
 
 class NonLinearConstraint(Constraint):
@@ -12,8 +13,21 @@ class NonLinearConstraint(Constraint):
 
     This class describes constraints of the form:
     g(A @ y + a) <= f @ y + b,
-    where g is a convex function.
+    where g is a convex function. Concrete non-linear constraints (e.g.
+    ``SocConstraint``) provide ``project`` and ``cv``; calling these on the base
+    class raises ``NotImplementedError``.
+
+    Attributes:
+        spec: Non-linear constraint specification.
     """
+
+    spec: NonLinearSpecification
+    _A: NLMatrix
+    _a: BatchedRHS | None
+    _f: NLLinearRHS | None
+    _b: BatchedScalar | None
+    _nl_type: NonLinearConstraintType = eqx.field(static=True)
+    _dim: int = eqx.field(static=True)
 
     def __init__(
         self,
@@ -36,39 +50,23 @@ class NonLinearConstraint(Constraint):
         self._nl_type = spec.nl_type
 
     @property
-    def A(self) -> jnp.ndarray:
-        """Matrix for linear transformation before non-linear function g.
-
-        Returns:
-            jnp.ndarray: Shape (batch_size, constraint_dim, variable_dim)
-        """
+    def A(self) -> NLMatrix:
+        """Matrix for linear transformation before non-linear function g."""
         return self._A
 
     @property
-    def a(self) -> jnp.ndarray | None:
-        """Offset vector before non-linear function g.
-
-        Returns:
-            Optional[jnp.ndarray]: Shape (batch_size, constraint_dim, 1)
-        """
+    def a(self) -> BatchedRHS | None:
+        """Offset vector before non-linear function g."""
         return self._a
 
     @property
-    def f(self) -> jnp.ndarray | None:
-        """Linear coefficients on the right-hand side.
-
-        Returns:
-            Optional[jnp.ndarray]: Shape (batch_size, 1, variable_dim)
-        """
+    def f(self) -> NLLinearRHS | None:
+        """Linear coefficients on the right-hand side."""
         return self._f
 
     @property
-    def b(self) -> jnp.ndarray | None:
-        """Constant offset on the right-hand side.
-
-        Returns:
-            Optional[jnp.ndarray]: Shape (batch_size, 1, 1)
-        """
+    def b(self) -> BatchedScalar | None:
+        """Constant offset on the right-hand side."""
         return self._b
 
     @property
@@ -83,9 +81,39 @@ class NonLinearConstraint(Constraint):
 
     @property
     def nl_type(self) -> NonLinearConstraintType:
-        """Return the type of non-linear constraint.
+        """Return the type of non-linear constraint."""
+        return self._nl_type
+
+    def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
+        """Project the input to the feasible region.
+
+        Args:
+            yraw: ProjectionInstance to project.
 
         Returns:
-            NonLinearConstraintType: The type of non-linear constraint.
+            The projected input.
+
+        Raises:
+            NotImplementedError: Always; the base class provides only the shared
+                parameter carrier. Use a concrete subclass (``SocConstraint``).
         """
-        return self._nl_type
+        raise NotImplementedError(
+            "NonLinearConstraint is a parameter carrier; use a concrete subclass."
+        )
+
+    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
+        """Compute the constraint violation.
+
+        Args:
+            yraw: ProjectionInstance to evaluate.
+
+        Returns:
+            The constraint violation for each point in the batch.
+
+        Raises:
+            NotImplementedError: Always; the base class provides only the shared
+                parameter carrier. Use a concrete subclass (``SocConstraint``).
+        """
+        raise NotImplementedError(
+            "NonLinearConstraint is a parameter carrier; use a concrete subclass."
+        )

--- a/src/pinet/constraints/soc_constraint.py
+++ b/src/pinet/constraints/soc_constraint.py
@@ -1,7 +1,10 @@
 """Second order cone constraint module."""
 
+import equinox as eqx
+import jax
 import jax.numpy as jnp
 
+from pinet._typing import BatchedIneqBound, BatchedScalar, Mask1D
 from pinet.constants import Constants
 from pinet.constraints.base import Constraint
 from pinet.dataclasses import ProjectionInstance, SocConstraintSpecification
@@ -15,7 +18,21 @@ class SocConstraint(Constraint):
     The SOC constraint set is defined as:
     || y_[mask_u] + a ||_2 <= y_[mask_t] + b
     where mask_t has one True element and b is a scalar.
+
+    Attributes:
+        mask_u: Mask selecting the variables that form the cone vector ``u``.
+        mask_t: Mask selecting the scalar variable ``t``.
+        a: Offset vector added to ``u``.
+        b: Scalar offset added to ``t``.
+        eps: Small epsilon for numerical stability of the projection direction.
     """
+
+    mask_u: Mask1D
+    mask_t: Mask1D
+    a: BatchedIneqBound
+    b: BatchedScalar
+    eps: float = eqx.field(static=True)
+    _dim: int = eqx.field(static=True)
 
     def __init__(
         self,
@@ -29,22 +46,27 @@ class SocConstraint(Constraint):
         if socspec.mask_u is None or socspec.mask_t is None:
             raise ValueError("Both mask_u and mask_t must be provided.")
         socspec.validate()
-        self.mask_u: jnp.ndarray = socspec.mask_u
-        self.mask_t: jnp.ndarray = socspec.mask_t
+        self.mask_u = socspec.mask_u
+        self.mask_t = socspec.mask_t
         self._dim = int(self.mask_u.shape[0])
         # For numerical stability of projection
         self.eps = SOC_CONSTRAINT_EPSILON
-        self.a: jnp.ndarray = (
+        self.a = (
             socspec.a
             if socspec.a is not None
             else jnp.zeros((1, int(self.mask_u.sum()), 1))
         )
-        self.b: jnp.ndarray = socspec.b if socspec.b is not None else jnp.zeros((1, 1, 1))
+        self.b = socspec.b if socspec.b is not None else jnp.zeros((1, 1, 1))
 
     def unpack_instance(
         self, inp: ProjectionInstance
     ) -> tuple[
-        jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray
+        Mask1D,
+        BatchedIneqBound,
+        Mask1D,
+        BatchedScalar,
+        BatchedIneqBound,
+        BatchedScalar,
     ]:
         """Unpack point to project in convenient form.
 
@@ -75,23 +97,23 @@ class SocConstraint(Constraint):
                 The .x attribute is the point to project.
 
         Returns:
-            ProjectionInstance: The projected point for each point in the batch.
+            The projected point for each point in the batch.
         """
         mask_u, u, mask_t, t, a, b = self.unpack_instance(yraw)
         norm_u = jnp.linalg.norm(u, axis=1, keepdims=True)
-        z: jnp.ndarray = jnp.concatenate([u, t], axis=1)
+        z: jax.Array = jnp.concatenate([u, t], axis=1)
 
-        proj1: jnp.ndarray = z
-        proj2: jnp.ndarray = jnp.zeros_like(z)
-        direction: jnp.ndarray = jnp.concatenate(
+        proj1: jax.Array = z
+        proj2: jax.Array = jnp.zeros_like(z)
+        direction: jax.Array = jnp.concatenate(
             [u / (norm_u + self.eps), jnp.ones_like(t)], axis=1
         )
-        proj3: jnp.ndarray = (t + norm_u) / 2 * direction
+        proj3: jax.Array = (t + norm_u) / 2 * direction
 
         when1 = norm_u <= t
         when2 = norm_u <= -t
-        inner: jnp.ndarray = jnp.where(when2, proj2, proj3)
-        final_proj: jnp.ndarray = jnp.where(when1, proj1, inner)
+        inner: jax.Array = jnp.where(when2, proj2, proj3)
+        final_proj: jax.Array = jnp.where(when1, proj1, inner)
 
         return yraw.update(
             x=yraw.x.at[:, mask_u, :]
@@ -100,18 +122,17 @@ class SocConstraint(Constraint):
             .set(final_proj[:, -1:, :] - b)
         )
 
-    def cv(self, yraw: ProjectionInstance) -> jnp.ndarray:
+    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
-        The SOC constraint is: ||u + a||_2 <= t + b
-        The violation is: max(0, ||u + a||_2 - (t + b))
+        The SOC constraint is: ||u + a||_2 <= t + b. The violation is
+        ``max(0, ||u + a||_2 - (t + b))``.
 
         Args:
             yraw: ProjectionInstance to evaluate.
 
         Returns:
-            jnp.ndarray: The constraint violation for each point in the batch.
-                Shape (batch_size, 1, 1).
+            The constraint violation for each point in the batch.
         """
         _mask_u, u, _mask_t, t, _a, _b = self.unpack_instance(yraw)
         norm_u = jnp.linalg.norm(u, axis=1, keepdims=True)
@@ -123,18 +144,10 @@ class SocConstraint(Constraint):
 
     @property
     def dim(self) -> int:
-        """Return the dimension of the constraint set.
-
-        Returns:
-            int: The dimension of the constraint set.
-        """
+        """Return the dimension of the constraint set."""
         return self._dim
 
     @property
     def n_constraints(self) -> int:
-        """Return the number of constraints.
-
-        Returns:
-            int: The number of constraints.
-        """
+        """Return the number of constraints."""
         return 1

--- a/src/pinet/dataclasses.py
+++ b/src/pinet/dataclasses.py
@@ -1,11 +1,21 @@
 """This file contains dataclasses used to encapsulate inputs for the Pinet layer."""
 
-import functools
-from dataclasses import dataclass, replace
+from dataclasses import replace
 
-import jax
+import equinox as eqx
 import jax.numpy as jnp
 
+from ._typing import (
+    BatchedEqMatrix,
+    BatchedEqPinv,
+    BatchedIneqBound,
+    BatchedPrimal,
+    BatchedRHS,
+    BatchedScalar,
+    Mask1D,
+    NLLinearRHS,
+    NLMatrix,
+)
 from .constants import Constants
 from .constraints.non_linear_types import L2NormType, NonLinearConstraintType, SOCType
 
@@ -21,24 +31,18 @@ EXPECTED_PROJECTION_NDIM = 3
 EXPECTED_SOC_TENSOR_NDIM = 3
 
 
-@jax.tree_util.register_dataclass
-@dataclass(frozen=True)
-class EqualityConstraintsSpecification:
+class EqualityConstraintsSpecification(eqx.Module):
     """Dataclass representing inputs used in forming equality constraints.
 
     Attributes:
-        b (Optional[jnp.ndarray]): Vector representing the RHS of the equality constraint.
-            Shape (batch_size, n_constraints, 1)
-        a_dyn (Optional[jnp.ndarray]): Matrix representing the LHS of the equality
-            constraint.
-            Shape (batch_size, n_constraints, dimension).
-        a_dyn_pinv (Optional[jnp.ndarray]): The pseudoinverse of the matrix a_dyn.
-            Shape (batch_size, dimension, n_constraints).
+        b: Vector representing the RHS of the equality constraint.
+        a_dyn: Matrix representing the LHS of the equality constraint.
+        a_dyn_pinv: The pseudoinverse of ``a_dyn``.
     """
 
-    b: jnp.ndarray | None = None
-    a_dyn: jnp.ndarray | None = None
-    a_dyn_pinv: jnp.ndarray | None = None
+    b: BatchedRHS | None = None
+    a_dyn: BatchedEqMatrix | None = None
+    a_dyn_pinv: BatchedEqPinv | None = None
 
     def validate(self) -> None:
         """Validate the equality constraints specification.
@@ -59,26 +63,23 @@ class EqualityConstraintsSpecification:
             **kwargs: Keyword arguments matching field names to update.
 
         Returns:
-            EqualityConstraintsSpecification: Updated instance.
+            Updated instance.
         """
         return replace(self, **kwargs)
 
 
-@jax.tree_util.register_dataclass
-@dataclass(frozen=True)
-class BoxConstraintSpecification:
+class BoxConstraintSpecification(eqx.Module):
     """Dataclass representing inputs used in forming box constraints.
 
     Attributes:
-        lb (jnp.ndarray): Lower bound of the box. Shape (batch_size, n_constraints, 1).
-        ub (jnp.ndarray): Upper bound of the box. Shape (batch_size, n_constraints, 1).
-        mask (jnp.ndarray | None):
-            Mask to apply the constraint only to some dimensions.
+        lb: Lower bound of the box.
+        ub: Upper bound of the box.
+        mask: Mask to apply the constraint only to some dimensions.
     """
 
-    lb: jnp.ndarray | None = None
-    ub: jnp.ndarray | None = None
-    mask: jnp.ndarray | None = None
+    lb: BatchedRHS | None = None
+    ub: BatchedRHS | None = None
+    mask: Mask1D | None = None
 
     def update(self, **kwargs: object) -> "BoxConstraintSpecification":
         """Update some attribute by keyword.
@@ -87,7 +88,7 @@ class BoxConstraintSpecification:
             **kwargs: Keyword arguments matching field names to update.
 
         Returns:
-            BoxConstraintSpecification: Updated instance.
+            Updated instance.
         """
         return replace(self, **kwargs)
 
@@ -167,29 +168,21 @@ class BoxConstraintSpecification:
         self._validate_mask()
 
 
-@jax.tree_util.register_dataclass
-@dataclass(frozen=True)
-class SocConstraintSpecification:
+class SocConstraintSpecification(eqx.Module):
     """Dataclass representing inputs used in forming second-order cone constraints.
 
     Attributes:
-        mask_u (Optional[jnp.ndarray]): Boolean mask indicating which variables
-            are part of the cone constraint vector u. Shape (dimension,).
-        mask_t (Optional[jnp.ndarray]): Boolean mask selecting a single
-            scalar variable t that serves as the cone constraint parameter.
-            Must have exactly one True value.
-            Shape (dimension,).
-        a (Optional[jnp.ndarray]): Coefficient matrix for the cone constraint vector u.
-            Shape (batch_size, n_u_variables, 1) where n_u_variables is the number of True
-            values in mask_u.
-        b (Optional[jnp.ndarray]): Coefficient vector for the cone constraint parameter t.
-            Shape (batch_size, 1, 1).
+        mask_u: Boolean mask selecting the variables that form the cone vector ``u``.
+        mask_t: Boolean mask selecting the scalar variable ``t``; must have exactly
+            one ``True`` entry.
+        a: Offset vector added to ``u``.
+        b: Scalar offset added to ``t``.
     """
 
-    mask_u: jnp.ndarray | None = None
-    mask_t: jnp.ndarray | None = None
-    a: jnp.ndarray | None = None
-    b: jnp.ndarray | None = None
+    mask_u: Mask1D | None = None
+    mask_t: Mask1D | None = None
+    a: BatchedIneqBound | None = None
+    b: BatchedScalar | None = None
 
     def update(self, **kwargs: object) -> "SocConstraintSpecification":
         """Update some attribute by keyword.
@@ -198,7 +191,7 @@ class SocConstraintSpecification:
             **kwargs: Field values to override.
 
         Returns:
-            SocConstraintSpecification: Updated instance.
+            Updated instance.
         """
         return replace(self, **kwargs)
 
@@ -287,8 +280,8 @@ class SocConstraintSpecification:
         """Convert SocConstraintSpecification to NonLinearSpecification.
 
         Returns:
-            NonLinearSpecification: A NonLinearSpecification instance with SOCType
-                and the constraints from this specification.
+            A ``NonLinearSpecification`` with ``SOCType`` and the constraints from
+            this specification.
         """
         self.validate()
         assert self.mask_t is not None  # narrowed by validate()
@@ -301,34 +294,22 @@ class SocConstraintSpecification:
         )
 
 
-@functools.partial(
-    jax.tree_util.register_dataclass,
-    data_fields=["A", "a", "f", "b"],
-    meta_fields=["nl_type"],
-)
-@dataclass(frozen=True)
-class NonLinearSpecification:
+class NonLinearSpecification(eqx.Module):
     """Dataclass representing inputs used in forming non-linear constraints.
 
     Attributes:
-        nl_type (NonLinearConstraintType): The type of non-linear constraint
-            (e.g., SOCType, L2NormType).
-        A (jnp.ndarray): Matrix for the constraint. Shape (1, m, n)
-            where m is the number of constraints and n is the number of variables.
-        a (Optional[jnp.ndarray]): Coefficient array for the constraint.
-            Shape (batch_size, m, 1) where m is the number of constraints.
-        f (Optional[jnp.ndarray]): Optional RHS vector for the constraint.
-            Shape (1, m, n) where m is the number of constraints
-            and n is the number of variables.
-        b (Optional[jnp.ndarray]): Optional scalar parameter for the constraint.
-            Shape (batch_size, 1, 1).
+        nl_type: The type of non-linear constraint (e.g., ``SOCType``, ``L2NormType``).
+        A: Matrix for the constraint (single shared matrix across the batch).
+        a: Per-instance coefficient vector for the constraint.
+        f: Optional RHS vector for the constraint (single shared vector).
+        b: Optional per-instance scalar parameter for the constraint.
     """
 
-    nl_type: NonLinearConstraintType
-    A: jnp.ndarray
-    a: jnp.ndarray | None = None
-    f: jnp.ndarray | None = None
-    b: jnp.ndarray | None = None
+    nl_type: NonLinearConstraintType = eqx.field(static=True)
+    A: NLMatrix
+    a: BatchedRHS | None = None
+    f: NLLinearRHS | None = None
+    b: BatchedScalar | None = None
 
     def update(self, **kwargs: object) -> "NonLinearSpecification":
         """Update some attribute by keyword.
@@ -337,7 +318,7 @@ class NonLinearSpecification:
             **kwargs: Field values to override.
 
         Returns:
-            NonLinearSpecification: Updated instance.
+            Updated instance.
         """
         return replace(self, **kwargs)
 
@@ -403,7 +384,7 @@ class NonLinearSpecification:
         """Convert NonLinearSpecification to primitive constraint specification.
 
         Returns:
-            SocConstraintSpecification: Equivalent primitive constraint spec.
+            Equivalent primitive constraint spec.
 
         Raises:
             NotImplementedError: If the non-linear type is not supported.
@@ -418,25 +399,18 @@ class NonLinearSpecification:
         )
 
 
-@jax.tree_util.register_dataclass
-@dataclass(frozen=True)
-class ProjectionInstance:
+class ProjectionInstance(eqx.Module):
     """A dataclass for encapsulating model input parameters.
 
     Attributes:
-        x (jnp.ndarray): The point to be projected.
-            Shape (batch_size, dimension, 1)
-        eq (Optional[EqualityConstraintsSpecification]):
-            Specification of the equality constraints, if any.
-        box (Optional[BoxConstraintSpecification]):
-            Specification of the box constraints, if any.
-        soc (Optional[SocConstraintSpecification]):
-            Specification of the second-order cone constraints, if any.
-        nl (Optional[list[NonLinearSpecification]]):
-            Specification of the non-linear constraints, if any.
+        x: The point to be projected.
+        eq: Specification of the equality constraints, if any.
+        box: Specification of the box constraints, if any.
+        soc: Specification of the second-order cone constraints, if any.
+        nl: Specification of the non-linear constraints, if any.
     """
 
-    x: jnp.ndarray
+    x: BatchedPrimal
     eq: EqualityConstraintsSpecification | None = None
     box: BoxConstraintSpecification | None = None
     soc: SocConstraintSpecification | None = None
@@ -464,34 +438,33 @@ class ProjectionInstance:
             **kwargs: Keyword arguments matching field names to update.
 
         Returns:
-            ProjectionInstance: Updated instance.
+            Updated instance.
         """
         return replace(self, **kwargs)
 
 
-@jax.tree_util.register_dataclass
-@dataclass(frozen=True)
-class EquilibrationParams:
+class EquilibrationParams(eqx.Module):
     """A dataclass for encapsulating the equilibration parameters.
 
     Attributes:
-        max_iter (int): Maximum number of iterations for the equilibration.
-        tol (float): Tolerance for convergence of the equilibration.
-        ord (float): Order of the norm used for convergence check.
-        col_scaling (bool): Whether to apply column scaling.
-        update_mode (str): Update mode for the equilibration.
-            Available options are:
-                - "Jacobi" means compute both row and column norms and update.
-                - "Gauss" means compute row, update, compute column, update.
-        safeguard (bool): Check if the condition number of a_dyn has decreased.
+        max_iter: Maximum number of iterations for the equilibration.
+        tol: Tolerance for convergence of the equilibration.
+        ord: Order of the norm used for convergence check.
+        col_scaling: Whether to apply column scaling.
+        update_mode: Update mode for the equilibration. Available options are:
+
+            * ``"Jacobi"``: compute both row and column norms and update.
+            * ``"Gauss"``: compute row, update, compute column, update.
+
+        safeguard: Check if the condition number of ``a_dyn`` has decreased.
     """
 
-    max_iter: int = EQUILIBRATION_DEFAULT_MAX_ITER
-    tol: float = EQUILIBRATION_DEFAULT_TOL
-    ord: float = EQUILIBRATION_DEFAULT_ORD
-    col_scaling: bool = EQUILIBRATION_DEFAULT_COL_SCALING
-    update_mode: str = EQUILIBRATION_DEFAULT_UPDATE_MODE
-    safeguard: bool = EQUILIBRATION_DEFAULT_SAFEGUARD
+    max_iter: int = eqx.field(static=True, default=EQUILIBRATION_DEFAULT_MAX_ITER)
+    tol: float = eqx.field(static=True, default=EQUILIBRATION_DEFAULT_TOL)
+    ord: float = eqx.field(static=True, default=EQUILIBRATION_DEFAULT_ORD)
+    col_scaling: bool = eqx.field(static=True, default=EQUILIBRATION_DEFAULT_COL_SCALING)
+    update_mode: str = eqx.field(static=True, default=EQUILIBRATION_DEFAULT_UPDATE_MODE)
+    safeguard: bool = eqx.field(static=True, default=EQUILIBRATION_DEFAULT_SAFEGUARD)
 
     def validate(self) -> None:
         """Validate the equilibration parameters.
@@ -515,6 +488,6 @@ class EquilibrationParams:
             **kwargs: Keyword arguments matching field names to update.
 
         Returns:
-            EquilibrationParams: Updated instance.
+            Updated instance.
         """
         return replace(self, **kwargs)

--- a/src/pinet/equilibration.py
+++ b/src/pinet/equilibration.py
@@ -1,15 +1,17 @@
 """Modified ruiz equilibration."""
 
 import jax.numpy as jnp
+from jaxtyping import Array, Float
 
+from ._typing import Matrix2D
 from .dataclasses import EquilibrationParams
 
 EXPECTED_MATRIX_NDIM = 2
 
 
 def ruiz_equilibration(
-    a_dyn: jnp.ndarray, params: EquilibrationParams
-) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    a_dyn: Matrix2D, params: EquilibrationParams
+) -> tuple[Matrix2D, Float[Array, "n_r"], Float[Array, "n_c"]]:
     """Perform modified Ruiz equilibration on matrix a_dyn.
 
     Ruiz equilibration iteratively scales the rows and columns of a_dyn so that
@@ -18,14 +20,12 @@ def ruiz_equilibration(
     TODO: Add equilibration for joint constraints.
 
     Args:
-        a_dyn: Input matrix with shape (n_r, n_c).
+        a_dyn: Input matrix.
         params: Parameters for equilibration.
 
     Returns:
-        scaled_a_dyn: Equilibrated matrix.
-        d_r: Row scaling factors
-            such that scaled_a_dyn = diag(d_r) @ a_dyn @ diag(d_c).
-        d_c: Column scaling factors.
+        A triple ``(scaled_a_dyn, d_r, d_c)`` such that
+        ``scaled_a_dyn = diag(d_r) @ a_dyn @ diag(d_c)``.
     """
     # Ruiz equilibration is defined here only for plain 2D matrices.
     assert a_dyn.ndim == EXPECTED_MATRIX_NDIM, (

--- a/src/pinet/project.py
+++ b/src/pinet/project.py
@@ -6,7 +6,7 @@ from functools import partial
 import jax
 from jax import numpy as jnp
 
-from ._typing import BatchedScalar, ScalingVector
+from ._typing import BatchedScalar, ColScaling, RowScaling
 from .constants import Constants
 from .constraints import (
     AffineInequalityConstraint,
@@ -393,8 +393,8 @@ def _project_general(
     ],
     step_final: Callable[[ProjectionInstance], ProjectionInstance],
     dim_lifted: int,
-    d_r: ScalingVector,
-    d_c: ScalingVector,
+    d_r: RowScaling,
+    d_c: ColScaling,
     yraw: ProjectionInstance,
     s0: ProjectionInstance | None = None,
     sigma: float = PROJECTION_DEFAULT_SIGMA,
@@ -458,8 +458,8 @@ def _project_general_custom(
     ],
     step_final: Callable[[ProjectionInstance], ProjectionInstance],
     dim_lifted: int,
-    d_r: ScalingVector,
-    d_c: ScalingVector,
+    d_r: RowScaling,
+    d_c: ColScaling,
     yraw: ProjectionInstance,
     s0: ProjectionInstance | None = None,
     sigma: float = PROJECTION_DEFAULT_SIGMA,
@@ -490,8 +490,8 @@ def _project_general_fwd(
     ],
     step_final: Callable[[ProjectionInstance], ProjectionInstance],
     dim_lifted: int,
-    d_r: ScalingVector,
-    d_c: ScalingVector,
+    d_r: RowScaling,
+    d_c: ColScaling,
     yraw: ProjectionInstance,
     s0: ProjectionInstance | None = None,
     sigma: float = PROJECTION_DEFAULT_SIGMA,
@@ -501,9 +501,7 @@ def _project_general_fwd(
     fpi: bool = False,
 ) -> tuple[
     tuple[ProjectionInstance, ProjectionInstance],
-    tuple[
-        ProjectionInstance, ProjectionInstance, ScalingVector, ScalingVector, float, float
-    ],
+    tuple[ProjectionInstance, ProjectionInstance, RowScaling, ColScaling, float, float],
 ]:
     # unpack trailing options that belong only to custom vjp
     # The decorated function returns a (ProjectionInstance, ProjectionInstance) tuple,
@@ -541,8 +539,8 @@ def _project_general_bwd(
     residuals: tuple[
         ProjectionInstance,
         ProjectionInstance,
-        ScalingVector,
-        ScalingVector,
+        RowScaling,
+        ColScaling,
         float,
         float,
     ],

--- a/src/pinet/project.py
+++ b/src/pinet/project.py
@@ -6,6 +6,7 @@ from functools import partial
 import jax
 from jax import numpy as jnp
 
+from ._typing import BatchedScalar, ScalingVector
 from .constants import Constants
 from .constraints import (
     AffineInequalityConstraint,
@@ -14,7 +15,11 @@ from .constraints import (
     EqualityConstraint,
     NonLinearConstraint,
 )
-from .dataclasses import EquilibrationParams, ProjectionInstance
+from .dataclasses import (
+    BoxConstraintSpecification,
+    EquilibrationParams,
+    ProjectionInstance,
+)
 from .equilibration import ruiz_equilibration
 from .solver import build_iteration_step, initialize
 
@@ -114,31 +119,23 @@ class Project:
                     ineq_constraint=self.ineq_constraint,
                     box_constraint=self.box_constraint,
                 )
-                (self.lifted_eq_constraint, self.lifted_box_constraint, self.lift) = (
-                    parser.parse(method=None)
-                )
+                (parsed_eq, parsed_box, self.lift) = parser.parse(method=None)
                 # Inequality-constrained parsing must yield a lifted equality.
-                assert self.lifted_eq_constraint is not None
+                assert parsed_eq is not None
                 # Inequality-constrained parsing must yield a lifted box.
-                assert self.lifted_box_constraint is not None
+                assert parsed_box is not None
                 # Setup always stores equilibration parameters before this branch runs.
                 assert self.equilibration_params is not None
                 # Only equilibrate when we have a single a_dyn.
-                if (
-                    not self.lifted_eq_constraint.var_a_dyn
-                    and self.lifted_eq_constraint.a_dyn.shape[0] == 1
-                ):
-                    scaled_a_dyn, self.d_r, self.d_c = ruiz_equilibration(
-                        self.lifted_eq_constraint.a_dyn[0], self.equilibration_params
+                if not parsed_eq.var_a_dyn and parsed_eq.a_dyn.shape[0] == 1:
+                    scaled_a_dyn_flat, d_r_flat, d_c_flat = ruiz_equilibration(
+                        parsed_eq.a_dyn[0], self.equilibration_params
                     )
-                    # Update a_dyn in lifted equality and setup projection
-                    self.lifted_eq_constraint.a_dyn = scaled_a_dyn.reshape(
-                        1,
-                        self.lifted_eq_constraint.a_dyn.shape[1],
-                        self.lifted_eq_constraint.a_dyn.shape[2],
+                    scaled_a_dyn = scaled_a_dyn_flat.reshape(
+                        1, parsed_eq.a_dyn.shape[1], parsed_eq.a_dyn.shape[2]
                     )
-                    self.d_r = self.d_r.reshape(1, -1, 1)
-                    self.d_c = self.d_c.reshape(1, -1, 1)
+                    self.d_r = d_r_flat.reshape(1, -1, 1)
+                    self.d_c = d_c_flat.reshape(1, -1, 1)
                 else:
                     # No equilibration for variable a_dyn
                     n_ineq = (
@@ -151,29 +148,36 @@ class Project:
                         if self.eq_constraint is not None
                         else 0
                     )
+                    scaled_a_dyn = parsed_eq.a_dyn
                     self.d_r = jnp.ones((1, n_eq + n_ineq, 1))
                     self.d_c = jnp.ones((1, self.dim_lifted, 1))
 
-                self.lifted_eq_constraint.method = "pinv"
-                self.lifted_eq_constraint.setup()
-
-                # Scale the equality RHS
-                self.lifted_eq_constraint.b *= self.d_r
-                # Scale the lifted box constraints
-                # The polytope path always produces a BoxConstraint (not a cartesian).
-                assert isinstance(self.lifted_box_constraint, BoxConstraint)
-                # BoxConstraint.__init__ guarantees mask/lb/ub are set.
-                assert self.lifted_box_constraint.mask is not None
-                assert self.lifted_box_constraint.lb is not None
-                assert self.lifted_box_constraint.ub is not None
-                mask = self.lifted_box_constraint.mask
-                scale = self.d_c[:, mask, :]
-                self.lifted_box_constraint.scale = 1 / scale
-                self.lifted_box_constraint.ub = (
-                    self.lifted_box_constraint.ub * self.lifted_box_constraint.scale
+                # Build the scaled lifted equality constraint with method="pinv".
+                self.lifted_eq_constraint = EqualityConstraint(
+                    a_dyn=scaled_a_dyn,
+                    b=parsed_eq.b * self.d_r,
+                    method="pinv",
+                    var_b=parsed_eq.var_b,
+                    var_a_dyn=parsed_eq.var_a_dyn,
                 )
-                self.lifted_box_constraint.lb = (
-                    self.lifted_box_constraint.lb * self.lifted_box_constraint.scale
+
+                # Scale the lifted box constraints.
+                # The polytope path always produces a BoxConstraint (not a cartesian).
+                assert isinstance(parsed_box, BoxConstraint)
+                # BoxConstraint.__init__ guarantees mask/lb/ub are set.
+                assert parsed_box.mask is not None
+                assert parsed_box.lb is not None
+                assert parsed_box.ub is not None
+                mask = parsed_box.mask
+                box_scale = 1 / self.d_c[:, mask, :]
+
+                self.lifted_box_constraint = BoxConstraint(
+                    BoxConstraintSpecification(
+                        lb=parsed_box.lb * box_scale,
+                        ub=parsed_box.ub * box_scale,
+                        mask=parsed_box.mask,
+                    ),
+                    scale=box_scale,
                 )
 
                 self.step_iteration, self.step_final = build_iteration_step(
@@ -272,15 +276,14 @@ class Project:
             d_r=self.d_r,
         )
 
-    def cv(self, y: ProjectionInstance) -> jnp.ndarray:
+    def cv(self, y: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
             y: Point to be evaluated.
-                Shape of y.x is (batch_size, dimension, 1).
 
         Returns:
-            jnp.ndarray: Constraint violation for each point in the batch.
+            Constraint violation for each point in the batch.
         """
         if self.is_single_simple_constraint:
             return self.single_constraint.cv(y)
@@ -390,8 +393,8 @@ def _project_general(
     ],
     step_final: Callable[[ProjectionInstance], ProjectionInstance],
     dim_lifted: int,
-    d_r: jnp.ndarray,
-    d_c: jnp.ndarray,
+    d_r: ScalingVector,
+    d_c: ScalingVector,
     yraw: ProjectionInstance,
     s0: ProjectionInstance | None = None,
     sigma: float = PROJECTION_DEFAULT_SIGMA,
@@ -408,15 +411,13 @@ def _project_general(
         d_r: Scaling factor for the rows.
         d_c: Scaling factor for the columns.
         yraw: Point to be projected.
-            Shape (batch_size, dimension, 1).
         s0: Initial value for the governing sequence.
         sigma: ADMM parameter.
         omega: ADMM parameter.
         n_iter: Number of iterations to run.
 
     Returns:
-        tuple[ProjectionInstance, ProjectionInstance]: First output is the projected
-            point, and second output is the value of the governing sequence.
+        A pair ``(projected_point, governing_sequence_value)``.
     """
     assert n_iter > 0, "Number of iterations must be positive."
 
@@ -457,8 +458,8 @@ def _project_general_custom(
     ],
     step_final: Callable[[ProjectionInstance], ProjectionInstance],
     dim_lifted: int,
-    d_r: jnp.ndarray,
-    d_c: jnp.ndarray,
+    d_r: ScalingVector,
+    d_c: ScalingVector,
     yraw: ProjectionInstance,
     s0: ProjectionInstance | None = None,
     sigma: float = PROJECTION_DEFAULT_SIGMA,
@@ -489,8 +490,8 @@ def _project_general_fwd(
     ],
     step_final: Callable[[ProjectionInstance], ProjectionInstance],
     dim_lifted: int,
-    d_r: jnp.ndarray,
-    d_c: jnp.ndarray,
+    d_r: ScalingVector,
+    d_c: ScalingVector,
     yraw: ProjectionInstance,
     s0: ProjectionInstance | None = None,
     sigma: float = PROJECTION_DEFAULT_SIGMA,
@@ -500,7 +501,9 @@ def _project_general_fwd(
     fpi: bool = False,
 ) -> tuple[
     tuple[ProjectionInstance, ProjectionInstance],
-    tuple[ProjectionInstance, ProjectionInstance, jnp.ndarray, jnp.ndarray, float, float],
+    tuple[
+        ProjectionInstance, ProjectionInstance, ScalingVector, ScalingVector, float, float
+    ],
 ]:
     # unpack trailing options that belong only to custom vjp
     # The decorated function returns a (ProjectionInstance, ProjectionInstance) tuple,
@@ -538,8 +541,8 @@ def _project_general_bwd(
     residuals: tuple[
         ProjectionInstance,
         ProjectionInstance,
-        jnp.ndarray,
-        jnp.ndarray,
+        ScalingVector,
+        ScalingVector,
         float,
         float,
     ],
@@ -551,11 +554,11 @@ def _project_general_bwd(
     implicit function theorem.
     Note that, the arguments are:
     (i) any arguments for the
-    forward that are not jnp.ndarray;
+    forward that are not arrays;
     (ii) residuals: tuple with auxiliary data from the forward pass;
     (iii) cotangent: incoming cotangents.
     The function returns a tuple where each element corresponds
-    to a jnp.ndarray from the input.
+    to an array from the input.
 
     Args:
         initialize_fn: Function to initialize the governing sequence.

--- a/src/pinet/solver/admm.py
+++ b/src/pinet/solver/admm.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 import jax.numpy as jnp
 
+from pinet._typing import ScalingVector
 from pinet.constants import Constants
 from pinet.constraints import (
     AffineInequalityConstraint,
@@ -24,12 +25,12 @@ def initialize(
     box_constraint: BoxConstraint | None,
     dim: int,
     dim_lifted: int,
-    d_r: jnp.ndarray,
+    d_r: ScalingVector,
 ) -> ProjectionInstance:
     """Initialize the ADMM solver state.
 
     Args:
-        yraw: Point to be projected. Shape (batch_size, dimension, 1).
+        yraw: Point to be projected.
         ineq_constraint: Inequality constraint.
         box_constraint: Box constraint.
         dim: Dimension of the original problem.
@@ -37,7 +38,7 @@ def initialize(
         d_r: Scaling factor for the lifted dimension.
 
     Returns:
-        ProjectionInstance: Initial state for the ADMM solver.
+        Initial state for the ADMM solver.
     """
     # Preprocess
     eq_spec = yraw.eq
@@ -83,7 +84,7 @@ def build_iteration_step(
     eq_constraint: EqualityConstraint,
     box_constraint: BoxConstraint | CartesianConstraint,
     dim: int,
-    scale: jnp.ndarray | float = 1.0,
+    scale: ScalingVector | float = 1.0,
 ) -> tuple[
     Callable[[ProjectionInstance, ProjectionInstance, float, float], ProjectionInstance],
     Callable[[ProjectionInstance], ProjectionInstance],
@@ -91,6 +92,7 @@ def build_iteration_step(
     """Build the iteration and result retrieval step for the ADMM solver.
 
     See https://web.stanford.edu/~boyd/papers/pdf/admm_distr_stats.pdf for details.
+
     Args:
         eq_constraint: (Lifted) Equality constraint.
         box_constraint: (Lifted) Box constraint.
@@ -98,12 +100,7 @@ def build_iteration_step(
         scale: Scaling of primal variables.
 
     Returns:
-        tuple[
-            Callable[[ProjectionInstance, jnp.ndarray, float, float], ProjectionInstance],
-            Callable[[ProjectionInstance], ProjectionInstance]
-        ]:
-            The first element is the iteration step,
-            the second element is the result retrieval step.
+        A pair ``(iteration_step, result_retrieval_step)``.
     """
 
     def iteration_step(
@@ -116,13 +113,12 @@ def build_iteration_step(
 
         Args:
             sk: State iterate for the ADMM solver.
-                .x of Shape (batch_size, lifted_dimension, 1).
-            yraw: Point to be projected. .x of Shape (batch_size, dimension, 1).
+            yraw: Point to be projected.
             sigma: ADMM parameter.
             omega: ADMM parameter.
 
         Returns:
-            ProjectionInstance: Next state iterate of the ADMM solver.
+            Next state iterate of the ADMM solver.
         """
         zk = eq_constraint.project(sk)
         # Reflection

--- a/src/pinet/solver/admm.py
+++ b/src/pinet/solver/admm.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 import jax.numpy as jnp
 
-from pinet._typing import ScalingVector
+from pinet._typing import ColScaling, RowScaling
 from pinet.constants import Constants
 from pinet.constraints import (
     AffineInequalityConstraint,
@@ -25,7 +25,7 @@ def initialize(
     box_constraint: BoxConstraint | None,
     dim: int,
     dim_lifted: int,
-    d_r: ScalingVector,
+    d_r: RowScaling,
 ) -> ProjectionInstance:
     """Initialize the ADMM solver state.
 
@@ -84,7 +84,7 @@ def build_iteration_step(
     eq_constraint: EqualityConstraint,
     box_constraint: BoxConstraint | CartesianConstraint,
     dim: int,
-    scale: ScalingVector | float = 1.0,
+    scale: ColScaling | float = 1.0,
 ) -> tuple[
     Callable[[ProjectionInstance, ProjectionInstance, float, float], ProjectionInstance],
     Callable[[ProjectionInstance], ProjectionInstance],

--- a/src/test/test_abstract_constraint.py
+++ b/src/test/test_abstract_constraint.py
@@ -1,0 +1,108 @@
+"""Tests for the abstract ``Constraint`` base class and its direct subclasses.
+
+These exercise the fallback / abstract branches that concrete constraint
+subclasses (``EqualityConstraint``, ``BoxConstraint``, ``SocConstraint``,
+``CartesianConstraint``) never hit, keeping the library coverage above the
+95% threshold.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+from pinet import (
+    EqualityConstraint,
+    EqualityConstraintsSpecification,
+    NonLinearSpecification,
+    ProjectionInstance,
+)
+from pinet.constraints.base import Constraint
+from pinet.constraints.non_linear import NonLinearConstraint
+from pinet.constraints.non_linear_types import SOCType
+
+
+def test_constraint_base_project_raises() -> None:
+    """``Constraint.project`` must fail with a named NotImplementedError."""
+    c = Constraint()
+    yraw = ProjectionInstance(x=jnp.zeros((1, 1, 1)))
+    with pytest.raises(NotImplementedError, match=r"Constraint\.project"):
+        c.project(yraw)
+
+
+def test_constraint_base_cv_raises() -> None:
+    """``Constraint.cv`` must fail with a named NotImplementedError."""
+    c = Constraint()
+    yraw = ProjectionInstance(x=jnp.zeros((1, 1, 1)))
+    with pytest.raises(NotImplementedError, match=r"Constraint\.cv"):
+        c.cv(yraw)
+
+
+def test_constraint_base_dim_raises() -> None:
+    """``Constraint.dim`` must fail with a named NotImplementedError."""
+    c = Constraint()
+    with pytest.raises(NotImplementedError, match=r"Constraint\.dim"):
+        _ = c.dim
+
+
+def test_constraint_base_n_constraints_raises() -> None:
+    """``Constraint.n_constraints`` must fail with a named NotImplementedError."""
+    c = Constraint()
+    with pytest.raises(NotImplementedError, match=r"Constraint\.n_constraints"):
+        _ = c.n_constraints
+
+
+def _make_nl_parameter_carrier() -> NonLinearConstraint:
+    """Build a minimal valid ``NonLinearConstraint`` parameter carrier."""
+    spec = NonLinearSpecification(
+        nl_type=SOCType,
+        A=jnp.zeros((1, 1, 2)),
+        a=jnp.zeros((1, 1, 1)),
+        f=None,
+        b=jnp.zeros((1, 1, 1)),
+    )
+    return NonLinearConstraint(spec)
+
+
+def test_nonlinear_constraint_n_constraints_is_one() -> None:
+    """Direct instantiation of ``NonLinearConstraint`` reports a single constraint."""
+    nl = _make_nl_parameter_carrier()
+    assert nl.n_constraints == 1
+
+
+def test_nonlinear_constraint_project_raises() -> None:
+    """``NonLinearConstraint.project`` signals the subclass contract."""
+    nl = _make_nl_parameter_carrier()
+    yraw = ProjectionInstance(x=jnp.zeros((1, 2, 1)))
+    with pytest.raises(NotImplementedError, match=r"parameter carrier"):
+        nl.project(yraw)
+
+
+def test_nonlinear_constraint_cv_raises() -> None:
+    """``NonLinearConstraint.cv`` signals the subclass contract."""
+    nl = _make_nl_parameter_carrier()
+    yraw = ProjectionInstance(x=jnp.zeros((1, 2, 1)))
+    with pytest.raises(NotImplementedError, match=r"parameter carrier"):
+        nl.cv(yraw)
+
+
+def test_equality_project_pinv_recomputes_when_pinv_missing() -> None:
+    """``project_pinv`` falls back to ``jnp.linalg.pinv`` when no pinv is cached.
+
+    Exercises the ``a_dyn_pinv is None`` branch inside ``project_pinv``: the
+    constraint is configured with ``var_a_dyn=True`` and the per-instance
+    spec supplies ``a_dyn`` but no ``a_dyn_pinv``.
+    """
+    a_dyn = jnp.array([[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]])
+    b = jnp.array([[[0.3], [-0.4]]])
+    eq = EqualityConstraint(a_dyn=a_dyn, b=b, method="pinv", var_a_dyn=True)
+
+    x = jnp.array([[[1.0], [2.0], [3.0]]])
+    yraw = ProjectionInstance(
+        x=x,
+        eq=EqualityConstraintsSpecification(a_dyn=a_dyn, b=b, a_dyn_pinv=None),
+    )
+    out = eq.project_pinv(yraw)
+    # The first two coordinates must match b exactly after projection.
+    assert jnp.allclose(out.x[0, 0, 0], 0.3)
+    assert jnp.allclose(out.x[0, 1, 0], -0.4)
+    # The unconstrained coordinate stays untouched.
+    assert jnp.allclose(out.x[0, 2, 0], 3.0)

--- a/src/test/test_cartesian_constraint.py
+++ b/src/test/test_cartesian_constraint.py
@@ -52,10 +52,8 @@ def test_nl_constraints_is_iterable():
 def test_non_box_soc_constraint_raises():
     """Test that non-Box/SOC constraint types raise ValueError."""
 
-    # Create a dummy constraint class
     class DummyConstraint(Constraint):
-        def __init__(self):
-            self._dim = 5
+        _dim: int = 5
 
         def project(self, yraw):
             return yraw

--- a/uv.lock
+++ b/uv.lock
@@ -844,6 +844,23 @@ wheels = [
 ]
 
 [[package]]
+name = "equinox"
+version = "0.13.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jax", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jaxtyping", version = "0.3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxtyping", version = "0.3.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions" },
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/54/9655a0546bbff95f93f6c81bdc6ecefecc7d92761b25fbbf4442d14491be/equinox-0.13.7.tar.gz", hash = "sha256:fcba83317fd53ee4505cfe32f919c13f9d4c3a68c266696dfa115129ed8c465f", size = 142098, upload-time = "2026-04-20T13:21:13.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/5e/28df919a8d5741a96fe7f56ac19493389f7a3de9c819c7a1ec3b2c557852/equinox-0.13.7-py3-none-any.whl", hash = "sha256:f2c8f4713ccdb0db117937d27dc6572a643bd2a15a1213e379cc6065e38a1731", size = 182093, upload-time = "2026-04-20T13:21:12.302Z" },
+]
+
+[[package]]
 name = "etils"
 version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1396,8 +1413,28 @@ wheels = [
 
 [[package]]
 name = "jaxtyping"
+version = "0.3.7"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "wadler-lindig", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/40/a2ea3ce0e3e5f540eb970de7792c90fa58fef1b27d34c83f9fa94fea4729/jaxtyping-0.3.7.tar.gz", hash = "sha256:3bd7d9beb7d3cb01a89f93f90581c6f4fff3e5c5dc3c9307e8f8687a040d10c4", size = 45721, upload-time = "2026-01-30T14:18:47.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/42/caf65e9a0576a3abadc537e2f831701ba9081f21317fb3be87d64451587a/jaxtyping-0.3.7-py3-none-any.whl", hash = "sha256:303ab8599edf412eeb40bf06c863e3168fa186cf0e7334703fa741ddd7046e66", size = 56101, upload-time = "2026-01-30T14:18:45.954Z" },
+]
+
+[[package]]
+name = "jaxtyping"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
 dependencies = [
     { name = "wadler-lindig", marker = "python_full_version >= '3.11'" },
 ]
@@ -2284,7 +2321,7 @@ dependencies = [
     { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jax", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jaxlib", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jaxtyping", marker = "python_full_version >= '3.11'" },
+    { name = "jaxtyping", version = "0.3.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "orbax-checkpoint", marker = "python_full_version >= '3.11'" },
     { name = "protobuf", marker = "python_full_version >= '3.11'" },
@@ -2452,6 +2489,7 @@ dependencies = [
     { name = "cvxpy", version = "1.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "cvxpylayers", version = "0.1.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "cvxpylayers", version = "1.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "equinox" },
     { name = "flax", version = "0.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "flax", version = "0.12.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "h5py" },
@@ -2459,6 +2497,8 @@ dependencies = [
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "jax", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jaxopt" },
+    { name = "jaxtyping", version = "0.3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxtyping", version = "0.3.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "matplotlib" },
     { name = "optax" },
     { name = "ruamel-yaml" },
@@ -2500,6 +2540,7 @@ requires-dist = [
     { name = "basedpyright", marker = "extra == 'dev'" },
     { name = "cvxpy", specifier = ">=1.6.6" },
     { name = "cvxpylayers", specifier = ">=0.1.9" },
+    { name = "equinox", specifier = ">=0.13.7" },
     { name = "flax", specifier = ">=0.10.2" },
     { name = "gitlint", marker = "extra == 'dev'", specifier = "==0.19.1" },
     { name = "h5py", specifier = ">=3.13.0" },
@@ -2507,6 +2548,7 @@ requires-dist = [
     { name = "jax", specifier = ">=0.6.2" },
     { name = "jax", extras = ["cuda12-pip"], marker = "extra == 'cuda12'", specifier = ">=0.6.2" },
     { name = "jaxopt", specifier = ">=0.8.5" },
+    { name = "jaxtyping", specifier = ">=0.3.7" },
     { name = "matplotlib", specifier = ">=3.10.1" },
     { name = "optax", specifier = ">=0.2.4" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.0.1" },


### PR DESCRIPTION
Stacked on top of #96. Base branch is `feat-improved-typing`; retarget to `dev` once #96 merges.

## Summary

Land the first two-thirds of the typing & pytrees modernization from [milestone #3](https://github.com/antonioterpin/pinet/milestone/3):

- **#97 — jaxtyping adoption.** Replace every `jnp.ndarray` / `jax.Array` annotation across `src/pinet/` with dtype/shape-parameterised aliases from a new `pinet._typing` module. Symbolic axis names (`B`, `n`, `m`, `n_ineq`, `d_lifted`, ...) are checked across call sites, so rank/shape bugs surface at trace time instead of via hand-rolled asserts. Ruff gains `F722`/`F821` in ignore so the quoted `Float[Array, "B m n"]` annotations lint clean.

- **#98 — equinox.Module migration.** All frozen dataclasses (`EqualityConstraintsSpecification`, `BoxConstraintSpecification`, `SocConstraintSpecification`, `NonLinearSpecification`, `ProjectionInstance`, `EquilibrationParams`) and every `Constraint` subclass (`EqualityConstraint`, `AffineInequalityConstraint`, `BoxConstraint`, `SocConstraint`, `NonLinearConstraint`, `CartesianConstraint`) move to `eqx.Module`. Drops the `@jax.tree_util.register_dataclass` + `@dataclass(frozen=True)` + per-class `update()` boilerplate; the manual `data_fields`/`meta_fields` split for `NonLinearSpecification` becomes a single `eqx.field(static=True)` on `nl_type`. `EqualityConstraint.setup()`'s dynamic rebinding of `self.project` is replaced by runtime dispatch on the static `method` field. `CartesianConstraint.update_fns` (a list of duplicated closures) is removed in favour of inline spec updates.

`Project.setup` is refactored so the equilibration / lifted-box scaling path constructs **fresh** `EqualityConstraint` / `BoxConstraint` instances from the scaled arrays instead of mutating frozen ones. `BoxConstraint.__init__` gains an optional `scale=` kwarg for this path. Semantics unchanged.

**Step 3 of #98** (`eqx.filter_jit` at the `Project` boundary) is deferred — the existing `jax.custom_vjp` + `partial(..., static_argnames=[...])` pattern is tightly coupled to `nondiff_argnames`, and swapping it would add risk without meaningful simplification. Can revisit in a separate PR if needed.

## Commits

1. `chore(typing): adopt jaxtyping across the library surface` — dep, `_typing.py`, ruff `F722`/`F821`, and the three library files (`solver/admm.py`, `equilibration.py`, `constraints/constraint_parser.py`) that are pure jaxtyping annotation changes.
2. `chore(pytrees): migrate constraints and frozen dataclasses to equinox.Module` — the full eqx migration, `Project.setup` refactor, `[tool.basedpyright]` config block with three targeted rule disables (each justified inline), and the one test fix.

## Config additions

`[tool.basedpyright]` block in `pyproject.toml` disables three diagnostics that conflict with the eqx.Module pattern, each commented inline with the reason:
- `reportMissingSuperCall = false` — eqx.Module's custom `__init__` doesn't call `super().__init__()`.
- `reportImplicitAbstractClass = false` — eqx enforces abstract methods natively at instantiation.
- `reportConstantRedefinition = false` — math-identifier convention for `_A`, `_B`, etc.

## Test plan

- [x] `uv run pytest` — 572 / 572 pass.
- [x] `uv run pre-commit run --all-files` — ruff, ruff-format, pydoclint, basedpyright, yaml/eof/whitespace all pass.
- [x] `uv run pre-commit run --hook-stage push --all-files` — all gates green at push stage.
- [x] Spot-check one benchmark run after rebasing on main to confirm no performance regression from the `Project.setup` instance-construction path.

## Remaining milestone work

After this PR lands, [milestone #3](https://github.com/antonioterpin/pinet/milestone/3) still has:
- [#99](https://github.com/antonioterpin/pinet/issues/99) — runtime shape/dtype checking via jaxtyping + beartype (now unblocked).
- [#100](https://github.com/antonioterpin/pinet/issues/100) — extend jaxtyping rollout to `src/tools/` and `src/benchmarks/`.

## Notes for the reviewer

- The jaxtyping commit is pure annotation refactor — zero runtime changes. The equinox commit is where to focus.
- `Project.setup()` still performs the same math; only the "apply scaling" step changed from mutation to construction. Cross-check the block that produces `self.lifted_eq_constraint` and `self.lifted_box_constraint`.
- `EqualityConstraint.__init__` now validates `method` against `["pinv", None]` up front (raises `ValueError`) rather than deferring to a `setup()` branch. Existing tests exercise both values.
- `NonLinearConstraint` is now formally instantiable (it has `project`/`cv` stubs that raise `NotImplementedError`) — matches existing call-site usage where it's passed as a parameter carrier into the parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
