### PR TITLE
chore(typing): wire trace-time runtime type checking via jaxtyping + beartype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "wandb>=0.20.1",
     "jaxtyping>=0.3.7",
     "equinox>=0.13.7",
+    "beartype>=0.22.9",
 ]
 
 # Optional dependencies

--- a/src/pinet/__init__.py
+++ b/src/pinet/__init__.py
@@ -1,29 +1,61 @@
-"""Hard constraint neural network package."""
+"""Hard constraint neural network package.
 
-from .constants import Constants
-from .constraints import (
-    AffineInequalityConstraint,
-    BoxConstraint,
-    CartesianConstraint,
-    ConstraintParser,
-    EqualityConstraint,
-    L2NormType,
-    NonLinearConstraint,
-    NonLinearConstraintType,
-    SocConstraint,
-    SOCType,
+Setting ``PINET_RUNTIME_CHECK=1`` before importing ``pinet`` installs the
+jaxtyping import hook, which wraps every function and class defined under
+``pinet.*`` with ``beartype.beartype`` so the shape/dtype annotations in
+``pinet._typing`` are enforced at trace time — a mismatched argument
+surfaces at the call site instead of deep inside a jitted function.
+
+The hook is **opt-in** for now. With the current annotations enabled the
+hook fires on broadcast-compatible (but not axis-equal) calls and on the
+negative-path validation tests that deliberately pass malformed input to
+check for a ``ValueError``. Flipping the default to on requires widening
+the annotations and updating those tests; tracked as a follow-up of #99.
+Beartype checks are O(1) on the hot path, so overhead lives on the first
+call / trace path.
+"""
+
+import contextlib
+import os
+
+from jaxtyping import install_import_hook
+
+_RUNTIME_CHECK = os.environ.get("PINET_RUNTIME_CHECK", "0") == "1"
+
+# The hook must wrap every submodule imported below so their annotations
+# are beartype-checked. Exiting the context removes the hook, so later
+# user-level ``import pinet.x`` calls are not instrumented twice.
+_hook = (
+    install_import_hook("pinet", "beartype.beartype")
+    if _RUNTIME_CHECK
+    else contextlib.nullcontext()
 )
-from .dataclasses import (
-    BoxConstraintSpecification,
-    EqualityConstraintsSpecification,
-    EquilibrationParams,
-    NonLinearSpecification,
-    ProjectionInstance,
-    SocConstraintSpecification,
-)
-from .equilibration import ruiz_equilibration
-from .project import Project
-from .solver import build_iteration_step
+
+with _hook:
+    from .constants import Constants
+    from .constraints import (
+        AffineInequalityConstraint,
+        BoxConstraint,
+        CartesianConstraint,
+        ConstraintParser,
+        EqualityConstraint,
+        L2NormType,
+        NonLinearConstraint,
+        NonLinearConstraintType,
+        SocConstraint,
+        SOCType,
+    )
+    from .dataclasses import (
+        BoxConstraintSpecification,
+        EqualityConstraintsSpecification,
+        EquilibrationParams,
+        NonLinearSpecification,
+        ProjectionInstance,
+        SocConstraintSpecification,
+    )
+    from .equilibration import ruiz_equilibration
+    from .project import Project
+    from .solver import build_iteration_step
 
 __all__ = [
     "AffineInequalityConstraint",

--- a/src/test/test_runtime_typecheck.py
+++ b/src/test/test_runtime_typecheck.py
@@ -1,0 +1,78 @@
+"""Smoke test for the ``PINET_RUNTIME_CHECK`` import hook.
+
+Verifies that setting ``PINET_RUNTIME_CHECK=1`` before importing ``pinet``
+activates the jaxtyping import hook with beartype, so a shape/dtype
+violation at a public API boundary raises a ``TypeCheckError`` at the
+call site instead of surfacing deep inside a jitted function.
+
+The test spawns a subprocess so the env var is set before ``pinet`` is
+imported — the parent test process already imported ``pinet`` without
+the hook.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_import_hook_catches_wrong_rank_when_enabled() -> None:
+    """With ``PINET_RUNTIME_CHECK=1``, constructing a ``ProjectionInstance``
+    with a 1D ``x`` raises ``TypeCheckError`` instead of silently
+    constructing an object that fails later.
+    """
+    script = textwrap.dedent(
+        """
+        import os, sys
+        os.environ["PINET_RUNTIME_CHECK"] = "1"
+        import jax.numpy as jnp
+        import pinet
+        try:
+            pinet.ProjectionInstance(x=jnp.zeros((5,)))
+        except Exception as exc:
+            # Expected: TypeCheckError from the beartype wrapper.
+            print(type(exc).__name__, flush=True)
+            sys.exit(0)
+        sys.exit(1)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        "Expected a TypeCheckError with hook enabled, got: "
+        f"{proc.stdout!r} / {proc.stderr!r}"
+    )
+    assert "TypeCheckError" in proc.stdout, (
+        f"Expected TypeCheckError, got: {proc.stdout!r}"
+    )
+
+
+def test_default_off_does_not_break_existing_imports() -> None:
+    """Without ``PINET_RUNTIME_CHECK``, a malformed ``ProjectionInstance``
+    constructs without a beartype check (the existing ``validate()``
+    methods are still the primary gate).
+    """
+    script = textwrap.dedent(
+        """
+        import os, sys
+        os.environ.pop("PINET_RUNTIME_CHECK", None)
+        import jax.numpy as jnp
+        import pinet
+        # Constructs without a TypeCheckError even with a 1D x.
+        inst = pinet.ProjectionInstance(x=jnp.zeros((5,)))
+        print(type(inst).__name__, flush=True)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ProjectionInstance" in proc.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,15 @@ wheels = [
 ]
 
 [[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -2485,6 +2494,7 @@ name = "pinet-hcnn"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "beartype" },
     { name = "cvxpy", version = "1.7.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "cvxpy", version = "1.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "cvxpylayers", version = "0.1.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2538,6 +2548,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "basedpyright", marker = "extra == 'dev'" },
+    { name = "beartype", specifier = ">=0.22.9" },
     { name = "cvxpy", specifier = ">=1.6.6" },
     { name = "cvxpylayers", specifier = ">=0.1.9" },
     { name = "equinox", specifier = ">=0.13.7" },


### PR DESCRIPTION
Stacked on top of #104 (which is stacked on #96). Base branch is `chore-jaxtyping`; retarget as each predecessor merges.

## Summary

Land the jaxtyping + beartype import-hook infrastructure from [#99](https://github.com/antonioterpin/pinet/issues/99). Once `PINET_RUNTIME_CHECK=1` is set before importing `pinet`, every function and class under `pinet.*` is wrapped with `beartype.beartype`, so the shape/dtype annotations introduced in #104 are enforced at trace time. A mismatched argument now surfaces at the call site as `TypeCheckError` instead of deep inside a jitted function.

- `pinet/__init__.py` — import-hook install inside a single `with` block, gated on `PINET_RUNTIME_CHECK`. Uses `contextlib.nullcontext()` when the var is unset so the cost is zero.
- `src/test/test_runtime_typecheck.py` — smoke tests that spawn subprocesses with and without `PINET_RUNTIME_CHECK` to verify both paths (a 1-D `x` to `ProjectionInstance` raises `TypeCheckError` with the hook on; constructs normally with the hook off).
- `pyproject.toml` / `uv.lock` — adds `beartype` as a runtime dependency.

## Why opt-in for now

Enabling the hook by default currently breaks 298 existing tests. They fall into three concrete categories — negative-path validation tests that asserted `ValueError` from `validate()` (now preempted by `TypeCheckError`), `SocConstraint.unpack_instance` / `BoxConstraint.get_params` return tuples whose annotations re-use the batch axis name across broadcast-compatible tensors, and one `NonLinearConstraint.nl_type` property mismatch. Shipping the infrastructure without that 300-test rewrite keeps the review tight.

Follow-up: [#105](https://github.com/antonioterpin/pinet/issues/105) tracks fixing the test suite under `PINET_RUNTIME_CHECK=1` and flipping the default to **on**.

## Test plan

- [x] `uv run pytest` — 580/580 pass (hook default-off; two new smoke tests added).
- [x] `PINET_RUNTIME_CHECK=1 python -c "import pinet; pinet.ProjectionInstance(x=jnp.zeros((5,)))"` — raises `TypeCheckError` at the call site.
- [x] `PINET_RUNTIME_CHECK=0 python -c "..."` (default) — constructs normally.
- [x] `uv run pre-commit run --all-files` — ruff, ruff-format, pydoclint, basedpyright, yaml/eof/whitespace all pass.
- [x] `uv run pre-commit run --hook-stage push --all-files` — same gates green at push stage.

## Notes for the reviewer

- The hook is scoped to `pinet` via `install_import_hook("pinet", "beartype.beartype")`. Third-party packages are untouched.
- `contextlib.nullcontext()` is used when the env var is unset so the disabled path has zero Python-level overhead beyond a single `os.environ.get` call.
- The smoke test deliberately spawns a subprocess because the parent pytest process already imported `pinet` without the hook — setting the env var mid-test would have no effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
