### PR TITLE
feat(parser): close non-linear coverage gaps (var_a_dyn=True + L2NormType)

### DIFF
--- a/src/pinet/constraints/cartesian_constraint.py
+++ b/src/pinet/constraints/cartesian_constraint.py
@@ -2,6 +2,7 @@
 
 import equinox as eqx
 import jax.numpy as jnp
+import numpy as np
 
 from pinet._typing import BatchedScalar
 from pinet.dataclasses import ProjectionInstance
@@ -107,23 +108,29 @@ class CartesianConstraint(Constraint):
                     f"Expected {dim}, got {constraint.dim}."
                 )
 
-        # Create a mask to track which dimensions are already used
-        used_mask = jnp.zeros(dim, dtype=bool)
+        # Track which dimensions are already used. Masks depend only on
+        # static shape information, so use ``numpy`` for the bookkeeping —
+        # ``jnp.any`` would return a tracer when ``CartesianConstraint`` is
+        # rebuilt inside the jitted ``solver.admm.initialize`` re-lift
+        # (``var_a_dyn=True`` path) and the ``if`` below would fail.
+        used_mask = np.zeros(dim, dtype=bool)
 
         for constraint in constraints:
             if isinstance(constraint, BoxConstraint):
                 # BoxConstraint.__init__ ensures mask is set.
                 assert constraint.mask is not None
-                new_mask = jnp.asarray(constraint.mask)
+                new_mask = np.asarray(constraint.mask)
             else:
                 # Narrow to SocConstraint so mask_u/mask_t are visible.
                 assert isinstance(constraint, SocConstraint)
-                new_mask = jnp.logical_or(constraint.mask_u, constraint.mask_t)
-            if jnp.any(jnp.logical_and(used_mask, new_mask)):
+                new_mask = np.logical_or(
+                    np.asarray(constraint.mask_u), np.asarray(constraint.mask_t)
+                )
+            if bool(np.any(np.logical_and(used_mask, new_mask))):
                 raise ValueError(
                     "Constraint masks overlap with previously defined constraints."
                 )
-            used_mask = jnp.logical_or(used_mask, new_mask)
+            used_mask = np.logical_or(used_mask, new_mask)
 
         return dim
 

--- a/src/pinet/constraints/constraint_parser.py
+++ b/src/pinet/constraints/constraint_parser.py
@@ -355,7 +355,7 @@ class ConstraintParser:
                 )
                 all_matrices.append(f_row)
                 dims[-1] += 1
-            else:
+            else:  # pragma: no cover -- defended by NonLinearSpecification._validate_type
                 raise ValueError(
                     f"Unsupported non-linear constraint type: {type(non_linear.nl_type)}"
                 )
@@ -481,7 +481,7 @@ class ConstraintParser:
                 )
                 prim_constraints.append(SocConstraint(socspec=socspec))
                 n_curr += nl.A.shape[1] + 1
-            else:
+            else:  # pragma: no cover -- defended by NonLinearSpecification._validate_type
                 raise ValueError(
                     f"Unsupported non-linear constraint type: {type(nl.nl_type)}"
                 )

--- a/src/pinet/constraints/constraint_parser.py
+++ b/src/pinet/constraints/constraint_parser.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 
 import jax.numpy as jnp
+import numpy as np
 
 from pinet._typing import ArrayLike
 from pinet.dataclasses import (
@@ -339,16 +340,44 @@ class ConstraintParser:
             assert non_linear.A is not None
             all_matrices.append(non_linear.A)
             dims.append(non_linear.A.shape[1])
-            if non_linear.f is not None:
-                all_matrices.append(non_linear.f)
+            # Normalise the linear RHS row so SOCType (with or without ``f``)
+            # and L2NormType all flow through the same lifted-auxiliary
+            # plumbing: every NL constraint contributes ``m`` aux rows for
+            # the ``u_aux = A x`` equality plus one row for the bound. For
+            # L2NormType (constant bound) and SOCType-without-f, the row is
+            # synthesised as zeros so the ``t_aux`` ends up identically zero
+            # and the SOC's own ``b`` offset carries the original scalar.
+            if non_linear.nl_type in (SOCType, L2NormType):
+                f_row: ArrayLike = (
+                    non_linear.f
+                    if non_linear.f is not None
+                    else jnp.zeros((1, 1, non_linear.A.shape[2]))
+                )
+                all_matrices.append(f_row)
                 dims[-1] += 1
-        # Dimension of auxiliary variables
-        n_aux = int(jnp.sum(jnp.array(dims[1:])))
-        n_tot = int(jnp.sum(jnp.array(dims)))
+            else:
+                raise ValueError(
+                    f"Unsupported non-linear constraint type: {type(non_linear.nl_type)}"
+                )
+        # Dimension of auxiliary variables. ``dims`` is a Python list of
+        # ``int`` shape values, so use the built-in ``sum`` to avoid
+        # producing a traced array inside ``jnp.sum`` (which would error
+        # when ``parse_non_linear`` is re-invoked from the jitted
+        # ``solver.admm.initialize`` for the ``var_a_dyn=True`` re-lift).
+        n_aux = sum(dims[1:])
+        n_tot = sum(dims)
+        # Tile each row block to the largest batch size before concatenating
+        # along the row axis. With ``var_a_dyn=True`` the equality matrix
+        # carries a per-instance batch (>1); inequality and non-linear
+        # matrices are constrained to batch 1 (validated above).
+        max_batch = max(M.shape[0] for M in all_matrices)
+        all_matrices = [
+            jnp.tile(M, (max_batch // M.shape[0], 1, 1)) for M in all_matrices
+        ]
         # Build first block column of lifted A
         lifted_a_b1 = jnp.concatenate(all_matrices, axis=1)
         # Append zeros
-        lifted_a_b2 = jnp.zeros((1, lifted_a_b1.shape[1], n_aux))
+        lifted_a_b2 = jnp.zeros((max_batch, lifted_a_b1.shape[1], n_aux))
         a_lifted = jnp.concatenate([lifted_a_b1, lifted_a_b2], axis=2)
         # Make matrix for auxiliaries
         aux_mat = jnp.zeros_like(a_lifted)
@@ -359,17 +388,20 @@ class ConstraintParser:
         )
         a_lifted = a_lifted + aux_mat
         b_lifted = jnp.concatenate(
-            [eq_constraint.b, jnp.zeros(shape=(1, n_aux, 1))],
+            [eq_constraint.b, jnp.zeros(shape=(eq_constraint.b.shape[0], n_aux, 1))],
             axis=1,
         )
-        # Define lifted equality constraints
+        # Define lifted equality constraints. ``var_a_dyn`` propagates from the
+        # input: when the user supplies a per-instance ``a_dyn`` via
+        # ``yraw.eq.a_dyn``, ``solver.admm.initialize`` re-runs
+        # ``parse_non_linear`` with the new value and produces a fresh lifted
+        # ``a_dyn`` / ``a_dyn_pinv`` whose top block reflects that input.
         eq_lifted = EqualityConstraint(
             a_dyn=a_lifted,
             b=b_lifted,
             method=method,
             var_b=eq_constraint.var_b,
-            # For now variable a_dyn is not supported on the non-linear path.
-            var_a_dyn=False,
+            var_a_dyn=eq_constraint.var_a_dyn,
         )
         # Setup primitive constraints -> Box, SOC, ...
         prim_constraints: list[SocConstraint] = []
@@ -416,31 +448,39 @@ class ConstraintParser:
                     mask=box_mask_lifted,
                 )
             )
-        # Non-linear constraints
+        # Non-linear constraints. SOCType and L2NormType both lower to the
+        # same SocConstraint here — the difference is whether ``t_aux`` is
+        # ``f @ x`` (SOC, set by the equality block above) or constant zero
+        # (L2Norm, synthesised f-row), and the ``b`` offset of the SOC
+        # carries the user-supplied scalar bound either way.
         for nl in nl_constraints:
             # Non-linear constraints need a linear-transformation matrix for lifting.
             assert nl.A is not None
-            if nl.nl_type == SOCType:
+            if nl.nl_type in (SOCType, L2NormType):
+                # Masks depend only on (static) dimensions, not on traced
+                # tensor values. Build them as ``numpy`` arrays so the
+                # downstream ``validate()`` (which calls ``.sum()``) returns
+                # a concrete Python scalar — important when
+                # ``parse_non_linear`` is re-invoked from the jitted
+                # ``solver.admm.initialize`` for ``var_a_dyn=True``.
                 socspec = SocConstraintSpecification(
-                    mask_u=jnp.array(
+                    mask_u=np.array(
                         [False] * n_curr
                         + [True] * nl.A.shape[1]
                         + [False] * (n_tot - n_curr - nl.A.shape[1]),
-                        dtype=jnp.bool_,
+                        dtype=np.bool_,
                     ),
-                    mask_t=jnp.array(
+                    mask_t=np.array(
                         [False] * (n_curr + nl.A.shape[1])
                         + [True]
                         + [False] * (n_tot - n_curr - nl.A.shape[1] - 1),
-                        dtype=jnp.bool_,
+                        dtype=np.bool_,
                     ),
                     a=nl.a,
                     b=nl.b,
                 )
                 prim_constraints.append(SocConstraint(socspec=socspec))
                 n_curr += nl.A.shape[1] + 1
-            elif nl.nl_type == L2NormType:
-                raise NotImplementedError("L2NormType is not implemented yet.")
             else:
                 raise ValueError(
                     f"Unsupported non-linear constraint type: {type(nl.nl_type)}"

--- a/src/pinet/dataclasses.py
+++ b/src/pinet/dataclasses.py
@@ -394,7 +394,11 @@ class NonLinearSpecification(eqx.Module):
         Raises:
             NotImplementedError: If the non-linear type is not supported.
         """
-        if self.nl_type == SOCType:
+        # SOCType (with or without ``f``) and L2NormType both project via
+        # the SOC primitive: the parser already lifts ``A x + a`` and
+        # ``f x + b`` (or ``b`` alone for L2) into auxiliary variables, so
+        # the downstream SOC sees the original ``a`` / ``b`` offsets.
+        if self.nl_type in (SOCType, L2NormType):
             return SocConstraintSpecification(
                 a=self.a,
                 b=self.b,

--- a/src/pinet/dataclasses.py
+++ b/src/pinet/dataclasses.py
@@ -403,7 +403,7 @@ class NonLinearSpecification(eqx.Module):
                 a=self.a,
                 b=self.b,
             )
-        raise NotImplementedError(
+        raise NotImplementedError(  # pragma: no cover -- defended by _validate_type
             f"Conversion to primitive spec not implemented for nl_type {self.nl_type}"
         )
 

--- a/src/pinet/project.py
+++ b/src/pinet/project.py
@@ -274,6 +274,7 @@ class Project:
             dim=self.dim,
             dim_lifted=self.dim_lifted,
             d_r=self.d_r,
+            nl_constraints=self.nl_constraints,
         )
 
     def cv(self, y: ProjectionInstance) -> BatchedScalar:

--- a/src/pinet/solver/admm.py
+++ b/src/pinet/solver/admm.py
@@ -12,6 +12,7 @@ from pinet.constraints import (
     CartesianConstraint,
     ConstraintParser,
     EqualityConstraint,
+    NonLinearConstraint,
 )
 from pinet.dataclasses import ProjectionInstance
 
@@ -26,6 +27,7 @@ def initialize(
     dim: int,
     dim_lifted: int,
     d_r: RowScaling,
+    nl_constraints: list[NonLinearConstraint] | None = None,
 ) -> ProjectionInstance:
     """Initialize the ADMM solver state.
 
@@ -36,6 +38,9 @@ def initialize(
         dim: Dimension of the original problem.
         dim_lifted: Dimension of the lifted problem.
         d_r: Scaling factor for the lifted dimension.
+        nl_constraints: Non-linear constraints, when present. Required for the
+            ``var_a_dyn=True`` re-lift to route through ``parse_non_linear``
+            instead of ``parse_polytope``.
 
     Returns:
         Initial state for the ADMM solver.
@@ -67,6 +72,7 @@ def initialize(
                 ),
                 ineq_constraint=ineq_constraint,
                 box_constraint=box_constraint,
+                nl_constraints=nl_constraints,
             )
             lifted_eq_constraint, _, _ = parser.parse(method="pinv")
             # Parsing must return the lifted equality constraint in this branch.

--- a/src/test/test_parser_and_nonlinear.py
+++ b/src/test/test_parser_and_nonlinear.py
@@ -356,35 +356,66 @@ def test_parse_non_linear_with_no_box_constraint():
     assert lifted.x.shape[1] > dim
 
 
-def test_parse_non_linear_l2_norm_type_raises_not_implemented():
-    """Test parser raises for L2 norm nonlinear constraints."""
-    A = jnp.array([[[1.0, 0.0]]])
-    b = jnp.array([[[0.0]]])
-    C = jnp.array([[[1.0, 0.0]]])
-    lb = jnp.array([[[-1.0]]])
-    ub = jnp.array([[[1.0]]])
+@pytest.mark.parametrize("seed, batch_size", product(SEEDS, BATCH_SIZES))
+def test_parse_non_linear_l2_norm_projection(seed: int, batch_size: int):
+    """L2NormType lifts to SOC and the projected point satisfies the L2 ball."""
+    dim = 4
+    m = 3
+    key = jrnd.PRNGKey(seed)
 
-    eq_constraint = EqualityConstraint(a_dyn=A, b=b, var_b=False)
-    ineq_constraint = AffineInequalityConstraint(constr_matrix=C, lb=lb, ub=ub)
+    key, kA, ka, kx = jrnd.split(key, 4)
+    A_l2 = jrnd.uniform(kA, shape=(1, m, dim), minval=-1.0, maxval=1.0)
+    a_l2 = jrnd.uniform(ka, shape=(1, m, 1), minval=-0.5, maxval=0.5)
+    b_l2 = jnp.full((1, 1, 1), 1.5)  # constant scalar bound
 
     nl_spec = NonLinearSpecification(
         nl_type=L2NormType,
-        A=jnp.array([[[1.0, 0.0], [0.0, 1.0]]]),
-        a=jnp.zeros((1, 2, 1)),
+        A=A_l2,
+        a=a_l2,
         f=None,
-        b=jnp.ones((1, 1, 1)),
+        b=b_l2,
     )
     nl_constraint = NonLinearConstraint(spec=nl_spec)
 
     parser = ConstraintParser(
-        eq_constraint=eq_constraint,
-        ineq_constraint=ineq_constraint,
+        eq_constraint=None,
+        ineq_constraint=None,
         box_constraint=None,
         nl_constraints=[nl_constraint],
     )
+    eq_lifted, cart_lifted, lift_fn = parser.parse(method="pinv")
+    # Narrow parser outputs before using them downstream.
+    assert eq_lifted is not None
+    assert isinstance(cart_lifted, CartesianConstraint)
 
-    with pytest.raises(NotImplementedError, match=r"L2NormType is not implemented"):
-        parser.parse()
+    # Project a random batch and confirm the L2 ball constraint is satisfied.
+    x = jrnd.uniform(kx, shape=(batch_size, dim, 1), minval=-3.0, maxval=3.0)
+    yraw = ProjectionInstance(x=x, nl=[nl_spec])
+    y_lifted = lift_fn(yraw)
+
+    iteration_step, final_step = build_iteration_step(
+        eq_constraint=eq_lifted,
+        box_constraint=cart_lifted,
+        dim=dim,
+    )
+    iteration_step = jax.jit(iteration_step)
+
+    sk = ProjectionInstance(
+        x=jnp.zeros((batch_size, y_lifted.x.shape[1], 1)),
+        nl=[nl_spec],
+    )
+    for _ in range(300):
+        sk = iteration_step(sk=sk, yraw=yraw, sigma=0.5, omega=1.7)
+
+    yk = final_step(sk)
+
+    # ``||A x + a||_2 <= b`` should hold on the projected primal x.
+    primal = yk.x[:, :dim, :]
+    norms = jnp.linalg.norm(A_l2 @ primal + a_l2, axis=1, keepdims=True)
+    assert jnp.all(norms <= b_l2 + 1e-3), (
+        f"L2 norm bound violated after projection: max={float(jnp.max(norms))}, "
+        f"bound={float(b_l2[0, 0, 0])}"
+    )
 
 
 def test_parse_non_linear_irrelevant_type_raises_value_error():
@@ -595,3 +626,80 @@ def test_box_and_nonlinear_constraints(seed, batch_size):
     # Verify projection feasibility
     cv_after = cart_lifted.cv(yk)
     assert jnp.all(cv_after < 1e-4)
+
+
+@pytest.mark.parametrize("seed, batch_size", product(SEEDS, [1, 5]))
+def test_project_var_a_dyn_with_nonlinear(seed: int, batch_size: int):
+    """``var_a_dyn=True`` works on the non-linear path.
+
+    The lifted ``a_dyn`` propagates the user-supplied per-instance
+    equality matrix through ``parse_non_linear`` (re-run inside
+    ``solver.admm.initialize``), and the projection still satisfies
+    both the equality and SOC constraints.
+    """
+    from pinet import (  # noqa: PLC0415  -- isolate the heavy import to this test
+        EqualityConstraintsSpecification,
+        Project,
+    )
+
+    dim = 4
+    n_eq = 2
+    m_soc = 3
+    key = jrnd.PRNGKey(seed)
+
+    key, kA, kx_feas, kxinfeas, ka, kf = jrnd.split(key, 6)
+
+    # Per-instance equality matrix and a feasible point that satisfies it.
+    a_dyn = jrnd.uniform(kA, shape=(batch_size, n_eq, dim), minval=-1.0, maxval=1.0)
+    x_feas = jrnd.uniform(kx_feas, shape=(batch_size, dim, 1), minval=-1.0, maxval=1.0)
+    b_eq = a_dyn @ x_feas
+
+    # Build the SOC: ``||A_soc x + a_soc||_2 <= f_soc x + b_soc``.
+    A_soc = jrnd.uniform(kA, shape=(1, m_soc, dim), minval=-1.0, maxval=1.0)
+    a_soc = jrnd.uniform(ka, shape=(1, m_soc, 1), minval=-0.5, maxval=0.5)
+    f_soc = jrnd.uniform(kf, shape=(1, 1, dim), minval=-0.5, maxval=0.5)
+    soc_norm_at_feas = jnp.linalg.norm(A_soc @ x_feas + a_soc, axis=1, keepdims=True)
+    f_at_feas = f_soc @ x_feas
+    # Pick ``b_soc`` per-instance so the feasible point is on the SOC's interior.
+    b_soc = soc_norm_at_feas - f_at_feas + 0.5
+
+    nl_spec = NonLinearSpecification(
+        nl_type=SOCType,
+        A=A_soc,
+        a=a_soc,
+        f=f_soc,
+        b=b_soc,
+    )
+    nl_constraint = NonLinearConstraint(spec=nl_spec)
+
+    # Construct ``Project`` with ``var_a_dyn=True`` so the per-instance
+    # ``a_dyn`` is supplied at projection time via ``yraw.eq``.
+    eq_constraint = EqualityConstraint(
+        a_dyn=a_dyn, b=b_eq, method="pinv", var_a_dyn=True, var_b=True
+    )
+    project_layer = Project(
+        eq_constraint=eq_constraint,
+        nl_constraints=[nl_constraint],
+    )
+
+    # Project an infeasible point.
+    x_infeas = jrnd.uniform(kxinfeas, shape=(batch_size, dim, 1), minval=-3.0, maxval=3.0)
+    yraw = ProjectionInstance(
+        x=x_infeas,
+        eq=EqualityConstraintsSpecification(a_dyn=a_dyn, b=b_eq),
+        nl=[nl_spec],
+    )
+    yk, _ = project_layer.call(yraw=yraw, n_iter=500)
+    primal = yk.x[:, :dim, :]
+
+    # Equality holds.
+    assert jnp.allclose(a_dyn @ primal, b_eq, atol=1e-4), (
+        "Per-instance equality constraint violated under var_a_dyn=True."
+    )
+    # SOC holds.
+    soc_lhs = jnp.linalg.norm(A_soc @ primal + a_soc, axis=1, keepdims=True)
+    soc_rhs = f_soc @ primal + b_soc
+    assert jnp.all(soc_lhs <= soc_rhs + 1e-3), (
+        f"SOC constraint violated under var_a_dyn=True: "
+        f"max LHS-RHS={float(jnp.max(soc_lhs - soc_rhs))}"
+    )


### PR DESCRIPTION
Stacked on top of #108 (→ #107 → #106 → #104 → #96). Base branch is `chore-runtime-typecheck-default-on`; retarget as each predecessor merges.

## Summary

Closes the two open items on [#31](https://github.com/antonioterpin/pinet/issues/31) — the gaps the dispatch fix in PR #96 left for follow-up:

1. **`var_a_dyn=True` is now supported on the non-linear path.** Previously hard-wired off in `parse_non_linear`. The lift propagates the flag, and `solver.admm.initialize` learns about `nl_constraints` so `parser.parse(method="pinv")` re-runs through `parse_non_linear` when the user supplies a fresh `a_dyn` via `yraw.eq`.

2. **`L2NormType` is implemented.** Constraint `||A x + a||_2 <= b` (constant scalar bound). Collapsed onto the existing SOC plumbing by synthesising a zero linear-RHS row in `parse_non_linear`: every NL constraint now contributes `m` aux rows for `u_aux = A x` plus one `t_aux` row whose value is either `f x` (SOC) or `0` (L2Norm). The `SocConstraint` then carries the user's `a`/`b` offsets, so for L2 the resulting check is `||u_aux + a||_2 <= 0 + b = b`. `NonLinearSpecification.to_primitive_spec` accepts `L2NormType` for the same reason.

## Lift correctness fixes that fell out

- **Batch tiling.** `parse_non_linear` now tiles each row block to the largest batch size before `jnp.concatenate(..., axis=1)`. The old code assumed every block had batch 1 — fine for static `a_dyn`, broken under `var_a_dyn=True` where the user supplies a per-instance batch.
- **`b_lifted` batch.** Zero-pads at the equality-constraint's batch instead of literal `1`, matching the (possibly batched) lifted `a_dyn`.

## Jit-friendliness

The re-lift now happens inside the jitted `Project.call` / `initialize` flow, so `parse_non_linear` had to be made trace-safe:

- **`n_aux` / `n_tot`** use Python `sum` instead of `int(jnp.sum(jnp.array(dims)))`. `dims` is a Python list of ints; the `jnp` round-trip produced a tracer that `int(...)` couldn't consume under jit.
- **SOC masks** in `parse_non_linear` are `np.array`s. They depend only on static dims, and `SocConstraintSpecification.validate`'s `mask_t.sum() != 1` check needs a concrete Python scalar — a traced `jnp` mask raises `TracerBoolConversionError`.
- **`CartesianConstraint._validate_constraints`** switches its overlap-tracking `used_mask` and the `if any(...)` guard to `numpy` for the same reason.

## Tests

- `test_parse_non_linear_l2_norm_projection` — parametrised over three seeds × three batch sizes; builds an L2 ball and asserts `||A x + a||_2 <= b` holds on the projected primal end-to-end.
- `test_project_var_a_dyn_with_nonlinear` — parametrised over three seeds × two batch sizes; builds a per-instance equality matrix together with an SOC and confirms both constraints hold after projection.

## Test plan

- [x] `uv run pytest` — 596/596 (582 existing + 14 new).
- [x] `uv run pre-commit run --all-files` — ruff, ruff-format, pydoclint, basedpyright, yaml/eof/whitespace all pass.
- [x] `uv run pre-commit run --hook-stage push --all-files` — green.

## Notes for the reviewer

- The `parse_non_linear` body changed in three places (matrix tiling, jit-safe `n_aux`, `numpy` masks). The math is unchanged; the changes are purely about making the lift work under both static and per-instance `a_dyn`, and under both eager and jit-traced execution.
- `L2NormType` is implemented by mapping it to SOC at parse time (synthetic `f=0`). The user-facing `NonLinearSpecification` validation still rejects `L2Norm` with `f` set, since "L2 with linear RHS" should use SOC explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
