### PR TITLE
chore(typing): extend jaxtyping rollout to tools/ and benchmarks/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,17 +101,23 @@ ignore = [
 # jaxtyping string-shape annotations (``Float[Array, "B m n"]``) trigger F722
 # (syntax error in forward annotation) and F821 (undefined name) because the
 # quoted axis names are not module-level symbols. Scope the ignore to the
-# library files that actually use those annotations so F722/F821 stay active
-# everywhere else (tests, benchmarks, tools).
+# directories that actually use those annotations so F722/F821 stay active
+# in tests.
 "src/pinet/**" = [
     "F722",
     "F821",
 ]
-"src/test/**" = [
-    "PLR2004", # Magic values are fine in tests.
+"src/tools/**" = [
+    "F722",
+    "F821",
 ]
 "src/benchmarks/**" = [
+    "F722",
+    "F821",
     "PLR2004", # Magic values are fine in benchmark scripts.
+]
+"src/test/**" = [
+    "PLR2004", # Magic values are fine in tests.
 ]
 
 [tool.ruff.lint.pep8-naming]

--- a/src/benchmarks/QP/generate_qp.py
+++ b/src/benchmarks/QP/generate_qp.py
@@ -16,14 +16,14 @@ jax.config.update("jax_enable_x64", True)
 
 
 def solve_problems(
-    q_mat: jnp.ndarray,
-    p: jnp.ndarray,
-    a_dyn: jnp.ndarray,
-    x_data: jnp.ndarray,
-    g_mat: jnp.ndarray,
-    h: jnp.ndarray,
+    q_mat: jax.Array,
+    p: jax.Array,
+    a_dyn: jax.Array,
+    x_data: jax.Array,
+    g_mat: jax.Array,
+    h: jax.Array,
     convex: bool = True,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+) -> tuple[jax.Array, jax.Array]:
     """Compute the optimal solutions for problem instances.
 
     Args:
@@ -36,7 +36,7 @@ def solve_problems(
         convex: Whether the problem is convex or not.
 
     Returns:
-        tuple[jnp.ndarray, jnp.ndarray]:
+        tuple[jax.Array, jax.Array]:
             A tuple containing the objectives and optimal solutions.
 
     Raises:

--- a/src/benchmarks/QP/load_qp.py
+++ b/src/benchmarks/QP/load_qp.py
@@ -28,7 +28,7 @@ def _pick(data: Any, *keys: str) -> jnp.ndarray:
 
 
 # Load Instance Dataset
-class SimpleQPDataset(Dataset[tuple[jnp.ndarray, jnp.ndarray]]):
+class SimpleQPDataset(Dataset[tuple[jax.Array, jax.Array]]):
     """Dataset for simple QP benchmark."""
 
     def __init__(self, filepath: str) -> None:
@@ -60,7 +60,7 @@ class SimpleQPDataset(Dataset[tuple[jnp.ndarray, jnp.ndarray]]):
         """
         return self.x_data.shape[0]
 
-    def __getitem__(self, idx: int) -> tuple[jnp.ndarray, jnp.ndarray]:
+    def __getitem__(self, idx: int) -> tuple[jax.Array, jax.Array]:
         """Get item from dataset.
 
         Args:
@@ -79,9 +79,9 @@ def create_dataloaders(
     test_split: float = 0.1,
     shuffle: bool = True,
 ) -> tuple[
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]],
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]],
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]],
+    DataLoader[tuple[jax.Array, jax.Array]],
+    DataLoader[tuple[jax.Array, jax.Array]],
+    DataLoader[tuple[jax.Array, jax.Array]],
 ]:
     """Dataset loaders for training, validation and test.
 
@@ -123,7 +123,7 @@ def create_dataloaders(
     return train_loader, val_loader, test_loader
 
 
-class DC3Dataset(Dataset[tuple[jnp.ndarray, jnp.ndarray]]):
+class DC3Dataset(Dataset[tuple[jax.Array, jax.Array]]):
     """Dataset for importing DC3 problems."""
 
     def __init__(self, filepath: str, use_convex: bool):
@@ -163,7 +163,7 @@ class DC3Dataset(Dataset[tuple[jnp.ndarray, jnp.ndarray]]):
         """
         return self.x_data.shape[0]
 
-    def __getitem__(self, idx: int | jax.Array) -> tuple[jnp.ndarray, jnp.ndarray]:
+    def __getitem__(self, idx: int | jax.Array) -> tuple[jax.Array, jax.Array]:
         """Get item from dataset.
 
         Args:
@@ -210,11 +210,11 @@ class JaxDataLoader:
         """
         return (len(self.dataset) + self.batch_size - 1) // self.batch_size
 
-    def __iter__(self) -> Iterator[tuple[jnp.ndarray, jnp.ndarray]]:
+    def __iter__(self) -> Iterator[tuple[jax.Array, jax.Array]]:
         """Iterate over the dataset.
 
         Yields:
-            tuple[jnp.ndarray, jnp.ndarray]: Batch of input features and objective values.
+            tuple[jax.Array, jax.Array]: Batch of input features and objective values.
         """
         for start in range(0, len(self.dataset), self.batch_size):
             batch_idx = self._perm[start : start + self.batch_size]
@@ -234,7 +234,7 @@ def dc3_dataloader(
     use_convex: bool,
     batch_size: int = 512,
     shuffle: bool = True,
-) -> DataLoader[tuple[jnp.ndarray, jnp.ndarray]]:
+) -> DataLoader[tuple[jax.Array, jax.Array]]:
     """Dataset loader for training, validation, or test.
 
     Args:
@@ -270,15 +270,15 @@ def non_dc3_dataset_setup(
     batch_size: int,
     use_jax_loader: bool,
 ) -> tuple[
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]],
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]],
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]],
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    DataLoader[tuple[jax.Array, jax.Array]],
+    DataLoader[tuple[jax.Array, jax.Array]],
+    DataLoader[tuple[jax.Array, jax.Array]],
 ]:
     """Setup function for datasets generated with our script.
 
@@ -333,15 +333,15 @@ def dc3_dataset_setup(
     batch_size: int,
     use_jax_loader: bool,
 ) -> tuple[
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]] | JaxDataLoader,
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]] | JaxDataLoader,
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]] | JaxDataLoader,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    DataLoader[tuple[jax.Array, jax.Array]] | JaxDataLoader,
+    DataLoader[tuple[jax.Array, jax.Array]] | JaxDataLoader,
+    DataLoader[tuple[jax.Array, jax.Array]] | JaxDataLoader,
 ]:
     """Setup function for datasets generated with the DC3 script.
 
@@ -433,15 +433,15 @@ def load_data(
     use_jax_loader: bool = True,
     penalty: float = 0.0,
 ) -> tuple[
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    Callable[[jnp.ndarray], jnp.ndarray],
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]] | JaxDataLoader,
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]] | JaxDataLoader,
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]] | JaxDataLoader,
-    Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray],
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    Callable[[jax.Array], jax.Array],
+    DataLoader[tuple[jax.Array, jax.Array]] | JaxDataLoader,
+    DataLoader[tuple[jax.Array, jax.Array]] | JaxDataLoader,
+    DataLoader[tuple[jax.Array, jax.Array]] | JaxDataLoader,
+    Callable[[jax.Array, jax.Array], jax.Array],
 ]:
     """Load problem data.
 
@@ -481,7 +481,7 @@ def load_data(
 
     # Define loss/objective function
     # Predictions is of shape (batch_size, Y_DIM) and Q is of shape (Y_DIM, Y_DIM)
-    def quadratic_form(prediction: jnp.ndarray) -> jnp.ndarray:
+    def quadratic_form(prediction: jax.Array) -> jax.Array:
         """Evaluate the quadratic objective.
 
         Args:
@@ -492,7 +492,7 @@ def load_data(
         """
         return 0.5 * prediction.T @ q_mat @ prediction + p.T @ prediction
 
-    def quadratic_form_sine(prediction: jnp.ndarray) -> jnp.ndarray:
+    def quadratic_form_sine(prediction: jax.Array) -> jax.Array:
         """Evaluate the quadratic objective plus sine.
 
         Args:

--- a/src/benchmarks/QP/parse_results.py
+++ b/src/benchmarks/QP/parse_results.py
@@ -4,6 +4,7 @@ import argparse
 import csv
 import pathlib
 
+import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import numpy as np
@@ -13,7 +14,7 @@ def generate_bar_plot_data(
     id: str,
     config: str,
     filename: str,
-    opt_obj_test: jnp.ndarray,
+    opt_obj_test: jax.Array,
     plotting: bool = False,
 ) -> None:
     """Generate bar plot data for RS and CV from saved results.
@@ -100,7 +101,7 @@ def generate_learning_curves(
     id: str,
     config: str,
     filename: str,
-    opt_obj_valid: jnp.ndarray,
+    opt_obj_valid: jax.Array,
     plotting: bool = False,
 ) -> None:
     """Parse results and saves learning curves for RS and CV.
@@ -346,7 +347,7 @@ def save_optimal_objectives(id: str, config: str):
     )
 
 
-def load_optimal_objectives(id: str) -> tuple[jnp.ndarray, jnp.ndarray]:
+def load_optimal_objectives(id: str) -> tuple[jax.Array, jax.Array]:
     """Load optimal objectives for the validation and test set.
 
     Args:

--- a/src/benchmarks/QP/plotting.py
+++ b/src/benchmarks/QP/plotting.py
@@ -1,14 +1,15 @@
 """Plotting for benchmarks."""
 
+import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 
 
 def plot_rs_vs_cv(
-    obj_fun_test: jnp.ndarray,
-    obj_test: jnp.ndarray,
-    eq_viol_test: jnp.ndarray,
-    ineq_viol_test: jnp.ndarray,
+    obj_fun_test: jax.Array,
+    obj_test: jax.Array,
+    eq_viol_test: jax.Array,
+    ineq_viol_test: jax.Array,
     cvthres: float,
     rsthres: float,
 ):
@@ -25,8 +26,8 @@ def plot_rs_vs_cv(
     Returns:
         tuple:
             fig (matplotlib.figure.Figure): The created figure.
-            rs (jnp.ndarray or float): Computed relative suboptimality.
-            cv (jnp.ndarray or float): Computed constraint violations.
+            rs (jax.Array or float): Computed relative suboptimality.
+            cv (jax.Array or float): Computed constraint violations.
     """
     fig, ax = plt.subplots()
     # Relative suboptimality
@@ -69,7 +70,7 @@ def plot_rs_vs_cv(
 
 
 def plot_inference_boxes(
-    single_inference_times: jnp.ndarray, batch_inference_times: jnp.ndarray
+    single_inference_times: jax.Array, batch_inference_times: jax.Array
 ):
     """Plot box plots for single and batch inference.
 

--- a/src/benchmarks/QP/run_qp.py
+++ b/src/benchmarks/QP/run_qp.py
@@ -40,10 +40,10 @@ class LoggingDict:
 
     def update(
         self,
-        optimal_objective: jnp.ndarray,
-        objective: jnp.ndarray,
-        eqcv: jnp.ndarray,
-        ineqcv: jnp.ndarray,
+        optimal_objective: jax.Array,
+        objective: jax.Array,
+        eqcv: jax.Array,
+        ineqcv: jax.Array,
         train_time: float,
         inf_time: float,
     ) -> None:
@@ -64,7 +64,7 @@ class LoggingDict:
         self.dict["train_time"].append(train_time)
         self.dict["inf_time"].append(inf_time)
 
-    def as_array(self, label: str) -> jnp.ndarray:
+    def as_array(self, label: str) -> jax.Array:
         """Return the logging dictionary label as a jnp array.
 
         Args:
@@ -80,10 +80,10 @@ class LoggingDict:
 def evaluate_hcnn(
     loader: Any,
     state: train_state.TrainState,
-    batched_objective: Callable[[jnp.ndarray], jnp.ndarray],
-    a_dyn: jnp.ndarray,
-    g_mat: jnp.ndarray,
-    h: jnp.ndarray,
+    batched_objective: Callable[[jax.Array], jax.Array],
+    a_dyn: jax.Array,
+    g_mat: jax.Array,
+    h: jax.Array,
     prefix: str,
     time_evals: int = 10,
     tol_cv: float = 1e-3,
@@ -92,11 +92,11 @@ def evaluate_hcnn(
     instances: Sequence[int] | None = None,
     proj_method: str = "pinet",
 ) -> tuple[
-    jnp.ndarray,  # Objective values
-    jnp.ndarray,  # HCNN objective values
-    jnp.ndarray,  # Equality constraint violations
-    jnp.ndarray,  # Inequality constraint violations
-    jnp.ndarray,  # Evaluation times
+    jax.Array,  # Objective values
+    jax.Array,  # HCNN objective values
+    jax.Array,  # Equality constraint violations
+    jax.Array,  # Inequality constraint violations
+    jax.Array,  # Evaluation times
 ]:
     """Evaluate the performance of the HCNN.
 
@@ -226,10 +226,10 @@ def evaluate_instance(
     loader: Any,
     state: train_state.TrainState,
     use_dc3_dataset: bool,
-    batched_objective: Callable[[jnp.ndarray], jnp.ndarray],
-    a_dyn: jnp.ndarray,
-    g_mat: jnp.ndarray,
-    h: jnp.ndarray,
+    batched_objective: Callable[[jax.Array], jax.Array],
+    a_dyn: jax.Array,
+    g_mat: jax.Array,
+    h: jax.Array,
     prefix: str,
     proj_method: str = "pinet",
 ) -> None:

--- a/src/benchmarks/model.py
+++ b/src/benchmarks/model.py
@@ -21,11 +21,9 @@ from pinet import (
 
 from .other_projections import get_cvxpy_projection, get_jaxopt_projection
 
-ActivationFn = Callable[[jnp.ndarray], jnp.ndarray]
-ProjectionFn = Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]
-TrainStepFn = Callable[
-    [TrainState, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, TrainState]
-]
+ActivationFn = Callable[[jax.Array], jax.Array]
+ProjectionFn = Callable[[jax.Array, jax.Array], jax.Array]
+TrainStepFn = Callable[[TrainState, jax.Array, jax.Array], tuple[jax.Array, TrainState]]
 
 
 def setup_pinet(
@@ -106,10 +104,10 @@ def setup_pinet(
 
 
 def setup_jaxopt(
-    a_dyn: jnp.ndarray,
-    b: jnp.ndarray,
-    constr_matrix: jnp.ndarray,
-    ub: jnp.ndarray,
+    a_dyn: jax.Array,
+    b: jax.Array,
+    constr_matrix: jax.Array,
+    ub: jax.Array,
     setup_reps: int,
     hyperparameters: dict[str, Any],
 ) -> tuple[ProjectionFn, ProjectionFn, float]:
@@ -141,10 +139,10 @@ def setup_jaxopt(
 
 
 def setup_cvxpy(
-    a_dyn: jnp.ndarray,
-    b: jnp.ndarray,
-    constr_matrix: jnp.ndarray,
-    ub: jnp.ndarray,
+    a_dyn: jax.Array,
+    b: jax.Array,
+    constr_matrix: jax.Array,
+    ub: jax.Array,
     setup_reps: int,
     hyperparameters: dict[str, Any],
 ) -> tuple[
@@ -206,8 +204,8 @@ class HardConstrainedMLP(nn.Module):
     @nn.compact
     def __call__(
         self,
-        x: jnp.ndarray,
-        b: jnp.ndarray,
+        x: jax.Array,
+        b: jax.Array,
         test: bool,
     ):
         """Forward pass of the MLP with projection.
@@ -218,7 +216,7 @@ class HardConstrainedMLP(nn.Module):
             test: Whether to use the test projection.
 
         Returns:
-            jnp.ndarray: Output of the MLP after projection.
+            jax.Array: Output of the MLP after projection.
         """
         for features in self.features_list:
             x = nn.Dense(features)(x)
@@ -241,9 +239,9 @@ def build_model_and_train_step(
     project_test: ProjectionFn,
     raw_train: bool,
     raw_test: bool,
-    loss_fn: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray],
-    example_x: jnp.ndarray,
-    example_b: jnp.ndarray,
+    loss_fn: Callable[[jax.Array, jax.Array], jax.Array],
+    example_x: jax.Array,
+    example_b: jax.Array,
     jit: bool = True,
 ) -> tuple[
     nn.Module,
@@ -288,7 +286,7 @@ def build_model_and_train_step(
         test=False,
     )
 
-    def train_step(state, x_batch: jnp.ndarray, b_batch: jnp.ndarray):
+    def train_step(state, x_batch: jax.Array, b_batch: jax.Array):
         def _loss(p):
             preds = state.apply_fn({"params": p}, x=x_batch, b=b_batch, test=False)
             return loss_fn(preds, b_batch).mean()
@@ -306,11 +304,11 @@ def setup_model(
     rng_key: jax.Array,
     hyperparameters: dict[str, Any],
     proj_method: str,
-    a_dyn: jnp.ndarray,
-    x_data: jnp.ndarray,
-    g_mat: jnp.ndarray,
-    h: jnp.ndarray,
-    batched_loss: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray],
+    a_dyn: jax.Array,
+    x_data: jax.Array,
+    g_mat: jax.Array,
+    h: jax.Array,
+    batched_loss: Callable[[jax.Array, jax.Array], jax.Array],
     setup_reps: int = 10,
 ) -> tuple[
     nn.Module,

--- a/src/benchmarks/other_projections.py
+++ b/src/benchmarks/other_projections.py
@@ -13,12 +13,12 @@ jax.config.update("jax_enable_x64", True)
 
 
 def get_jaxopt_projection(
-    a_dyn: jnp.ndarray,
-    constr_matrix: jnp.ndarray,
-    d: jnp.ndarray,
+    a_dyn: jax.Array,
+    constr_matrix: jax.Array,
+    d: jax.Array,
     dim: int,
     tol: float = 1e-3,
-) -> Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
+) -> Callable[[jax.Array, jax.Array], jax.Array]:
     """Compute a batched projection function for polyhedral constraints using JAXopt.
 
     This function creates a projection operator using the jaxopt.OSQP solver.
@@ -38,7 +38,7 @@ def get_jaxopt_projection(
         tol: Tolerance for the solver. Defaults to 1e-3.
 
     Returns:
-        Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
+        Callable[[jax.Array, jax.Array], jax.Array]:
         A JIT-compiled and vectorized function
         that takes a batch of input vectors (shape: (batch_size, dim))
         and returns their corresponding projections.
@@ -62,9 +62,9 @@ def get_jaxopt_projection(
 
 
 def get_cvxpy_projection(
-    a_dyn: jnp.ndarray,
-    constr_matrix: jnp.ndarray,
-    d: jnp.ndarray,
+    a_dyn: jax.Array,
+    constr_matrix: jax.Array,
+    d: jax.Array,
     dim: int,
 ) -> CvxpyLayer:
     """Constructs and returns a CVXPY-based projection layer callable.
@@ -82,11 +82,11 @@ def get_cvxpy_projection(
         dim: Dimension of the variable x.
 
     Returns:
-        Callable[[jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray]]:
+        Callable[[jax.Array, jax.Array], tuple[jax.Array]]:
         A callable CVXPY layer that takes two parameters:
         an input vector (xproj) to be projected and a corresponding vector b for
         the equality constraints.
-        The callable returns the projected vector as a jnp.ndarray.
+        The callable returns the projected vector as a jax.Array.
     """
     n_eq = a_dyn.shape[0]
     ycvxpy = cp.Variable(dim)

--- a/src/benchmarks/toy_MPC/load_toy_mpc.py
+++ b/src/benchmarks/toy_MPC/load_toy_mpc.py
@@ -27,10 +27,10 @@ def _pick(data: Any, *keys: str) -> jnp.ndarray:
 
 
 # Load Instance Dataset
-class ToyMPCDataset(Dataset[tuple[jnp.ndarray, jnp.ndarray]]):
+class ToyMPCDataset(Dataset[tuple[jax.Array, jax.Array]]):
     """Dataset for toy MPC benchmark."""
 
-    def __init__(self, data: dict[str, jnp.ndarray], const: dict[str, jnp.ndarray]):
+    def __init__(self, data: dict[str, jax.Array], const: dict[str, jax.Array]):
         """Initialize dataset.
 
         Args:
@@ -63,14 +63,14 @@ class ToyMPCDataset(Dataset[tuple[jnp.ndarray, jnp.ndarray]]):
         """
         return self.x0sets.shape[0]
 
-    def __getitem__(self, idx: int | jax.Array) -> tuple[jnp.ndarray, jnp.ndarray]:
+    def __getitem__(self, idx: int | jax.Array) -> tuple[jax.Array, jax.Array]:
         """Get item from dataset.
 
         Args:
             idx: Index of the item to retrieve.
 
         Returns:
-            tuple[jnp.ndarray, jnp.ndarray]:
+            tuple[jax.Array, jax.Array]:
                 Tuple containing the initial condition and the objective value.
         """
         return self.x0sets[idx], self.objectives[idx]
@@ -83,9 +83,9 @@ def create_dataloaders(
     test_split: float = 0.1,
     shuffle: bool = True,
 ) -> tuple[
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]],
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]],
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]],
+    DataLoader[tuple[jax.Array, jax.Array]],
+    DataLoader[tuple[jax.Array, jax.Array]],
+    DataLoader[tuple[jax.Array, jax.Array]],
 ]:
     """Dataset loaders for training, validation and test.
 
@@ -188,20 +188,20 @@ def load_data(
     test_split: float = 0.1,
     use_jax_loader: bool = True,
 ) -> tuple[
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
     float,
     int,
     int,
-    jnp.ndarray,
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]] | JaxDataLoaderMPC,
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]] | JaxDataLoaderMPC,
-    DataLoader[tuple[jnp.ndarray, jnp.ndarray]] | JaxDataLoaderMPC,
-    Callable[[jnp.ndarray], jnp.ndarray],
+    jax.Array,
+    DataLoader[tuple[jax.Array, jax.Array]] | JaxDataLoaderMPC,
+    DataLoader[tuple[jax.Array, jax.Array]] | JaxDataLoaderMPC,
+    DataLoader[tuple[jax.Array, jax.Array]] | JaxDataLoaderMPC,
+    Callable[[jax.Array], jax.Array],
 ]:
     """Load problem data.
 
@@ -215,23 +215,23 @@ def load_data(
 
     Returns:
         tuple: A tuple containing:
-            - As (jnp.ndarray): System dynamics matrix.
-            - lbxs (jnp.ndarray): Lower bounds for state variables.
-            - ubxs (jnp.ndarray): Upper bounds for state variables.
-            - lbus (jnp.ndarray): Lower bounds for control inputs.
-            - ubus (jnp.ndarray): Upper bounds for control inputs.
-            - xhat (jnp.ndarray): Reference state.
+            - As (jax.Array): System dynamics matrix.
+            - lbxs (jax.Array): Lower bounds for state variables.
+            - ubxs (jax.Array): Upper bounds for state variables.
+            - lbus (jax.Array): Lower bounds for control inputs.
+            - ubus (jax.Array): Upper bounds for control inputs.
+            - xhat (jax.Array): Reference state.
             - alpha (float): Regularization parameter.
             - T (int): Time horizon.
             - base_dim (int): Dimension of the base state.
-            - X (jnp.ndarray): Initial conditions for the dataset.
+            - X (jax.Array): Initial conditions for the dataset.
             - train_loader: Training DataLoader or JaxDataLoaderMPC.
             - valid_loader: Validation DataLoader or JaxDataLoaderMPC.
             - test_loader: Test DataLoader or JaxDataLoaderMPC.
             - batched_objective: Function to compute the quadratic objective in batches.
     """
     dataset_path = os.path.join(os.path.dirname(__file__), "datasets", filepath)
-    all_data = cast(dict[str, jnp.ndarray], cast(object, jnp.load(dataset_path)))
+    all_data = cast(dict[str, jax.Array], cast(object, jnp.load(dataset_path)))
     toy_dataset = ToyMPCDataset(all_data, all_data)
     if not use_jax_loader:
         train_loader, valid_loader, test_loader = create_dataloaders(
@@ -302,14 +302,14 @@ def load_data(
     x_data = toy_dataset.x0sets
     dimx = lbxs.shape[1]
 
-    def quadratic_form(prediction: jnp.ndarray) -> jnp.ndarray:
+    def quadratic_form(prediction: jax.Array) -> jax.Array:
         """Evaluate the quadratic objective.
 
         Args:
             prediction: Predicted trajectory and controls for one instance.
 
         Returns:
-            jnp.ndarray: Scalar quadratic objective value.
+            jax.Array: Scalar quadratic objective value.
         """
         return jnp.sum(
             (prediction[:dimx] - jnp.tile(xhat[:, 0], horizon + 1)) ** 2

--- a/src/benchmarks/toy_MPC/model.py
+++ b/src/benchmarks/toy_MPC/model.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from typing import Any
 
 import jax
-import jax.numpy as jnp
 from flax import linen as nn
 from flax.training.train_state import TrainState
 
@@ -15,16 +14,16 @@ from src.benchmarks.model import build_model_and_train_step, setup_pinet
 def setup_model(
     rng_key: jax.Array,
     hyperparameters: dict[str, Any],
-    a_dyn: jnp.ndarray,
-    x_data: jnp.ndarray,
-    b: jnp.ndarray,
-    lb: jnp.ndarray,
-    ub: jnp.ndarray,
-    batched_objective: Callable[[jnp.ndarray], jnp.ndarray],
+    a_dyn: jax.Array,
+    x_data: jax.Array,
+    b: jax.Array,
+    lb: jax.Array,
+    ub: jax.Array,
+    batched_objective: Callable[[jax.Array], jax.Array],
 ) -> tuple[
     nn.Module,
     dict[str, Any],
-    Callable[[TrainState, jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, TrainState]],
+    Callable[[TrainState, jax.Array, jax.Array], tuple[jax.Array, TrainState]],
 ]:
     """Receives problem (hyper)parameters and returns the model and its parameters.
 

--- a/src/benchmarks/toy_MPC/plotting.py
+++ b/src/benchmarks/toy_MPC/plotting.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Sequence
 from typing import cast
 
 import cvxpy as cp
+import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import numpy as np
@@ -11,16 +12,16 @@ from cvxpy.constraints.constraint import Constraint as CvxpyConstraint
 from flax.training.train_state import TrainState
 from matplotlib.patches import Rectangle
 
-BatchLoader = Iterable[tuple[jnp.ndarray, jnp.ndarray]]
+BatchLoader = Iterable[tuple[jax.Array, jax.Array]]
 
 
 def plot_training(
     train_loader: BatchLoader,
     valid_loader: BatchLoader,
-    training_losses: Sequence[float | jnp.ndarray],
-    validation_losses: Sequence[float | jnp.ndarray],
-    eqcvs: Sequence[float | jnp.ndarray],
-    ineqcvs: Sequence[float | jnp.ndarray],
+    training_losses: Sequence[float | jax.Array],
+    validation_losses: Sequence[float | jax.Array],
+    eqcvs: Sequence[float | jax.Array],
+    ineqcvs: Sequence[float | jax.Array],
 ) -> None:
     """Plot training curves.
 
@@ -87,20 +88,20 @@ def plot_training(
 
 def generate_trajectories(
     state: TrainState,
-    a_dyn: jnp.ndarray,
-    lbxs: jnp.ndarray,
-    ubxs: jnp.ndarray,
-    lbus: jnp.ndarray,
-    ubus: jnp.ndarray,
+    a_dyn: jax.Array,
+    lbxs: jax.Array,
+    ubxs: jax.Array,
+    lbus: jax.Array,
+    ubus: jax.Array,
     alpha: float,
     base_dim: int,
     y_dim: int,
     dimx: int,
-    xhat: jnp.ndarray,
+    xhat: jax.Array,
     horizon: int,
-    lb: jnp.ndarray,
-    ub: jnp.ndarray,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+    lb: jax.Array,
+    ub: jax.Array,
+) -> tuple[jax.Array, jax.Array]:
     """Generates trajectories from pinet and solver.
 
     Args:
@@ -121,8 +122,8 @@ def generate_trajectories(
 
     Returns:
         tuple: A tuple containing:
-            - trajectories (jnp.ndarray): Predicted trajectories from the model.
-            - trajectories_cp (jnp.ndarray): Trajectories computed using cvxpy.
+            - trajectories (jax.Array): Predicted trajectories from the model.
+            - trajectories_cp (jax.Array): Trajectories computed using cvxpy.
     """
     ntraj = 1
     xinit = jnp.array([[-7, -5]]).reshape(ntraj, base_dim, 1)
@@ -158,7 +159,7 @@ def generate_trajectories(
         problem.solve(verbose=False)
         trajectories_cp = trajectories_cp.at[i].set(jnp.asarray(xcp.value).reshape(-1, 1))
 
-    def plot_trajectory(trajectory_pred: jnp.ndarray, trajectory_cp: jnp.ndarray) -> None:
+    def plot_trajectory(trajectory_pred: jax.Array, trajectory_cp: jax.Array) -> None:
         """Plots the trajectory in z.
 
         Args:

--- a/src/benchmarks/toy_MPC/run_toy_mpc.py
+++ b/src/benchmarks/toy_MPC/run_toy_mpc.py
@@ -28,26 +28,26 @@ from src.tools.utils import GracefulShutdown, Logger, load_configuration
 
 jax.config.update("jax_enable_x64", True)
 
-BatchLoader = Iterable[tuple[jnp.ndarray, jnp.ndarray]]
+BatchLoader = Iterable[tuple[jax.Array, jax.Array]]
 
 
 def evaluate_hcnn(
     loader: BatchLoader,
     state: train_state.TrainState,
-    batched_objective: Callable[[jnp.ndarray], jnp.ndarray],
-    a_dyn: jnp.ndarray,
-    lb: jnp.ndarray,
-    ub: jnp.ndarray,
+    batched_objective: Callable[[jax.Array], jax.Array],
+    a_dyn: jax.Array,
+    lb: jax.Array,
+    ub: jax.Array,
     prefix: str,
     time_evals: int = 10,
     print_res: bool = True,
     cv_tol: float = 1e-3,
     single_instance: bool = True,
 ) -> tuple[
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
-    jnp.ndarray,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
     float,
     float,
     float,
@@ -73,10 +73,10 @@ def evaluate_hcnn(
         constraint violations, average evaluation time, and standard deviation
         of the evaluation time.
     """
-    opt_obj_batches: list[jnp.ndarray] = []
-    hcnn_obj_batches: list[jnp.ndarray] = []
-    eq_cv_batches: list[jnp.ndarray] = []
-    ineq_cv_batches: list[jnp.ndarray] = []
+    opt_obj_batches: list[jax.Array] = []
+    hcnn_obj_batches: list[jax.Array] = []
+    eq_cv_batches: list[jax.Array] = []
+    ineq_cv_batches: list[jax.Array] = []
     # Placeholders, overwritten by the loop; kept so the post-loop usages have
     # valid references even if the loader yielded zero batches.
     x_data = jnp.zeros((0, 0, 1))
@@ -255,10 +255,10 @@ def main(
     n_epochs = hyperparameters["n_epochs"]
     eval_every = 1
     start = time.time()
-    trainig_losses: list[float | jnp.ndarray] = []
-    validation_losses: list[float | jnp.ndarray] = []
-    eqcvs: list[float | jnp.ndarray] = []
-    ineqcvs: list[float | jnp.ndarray] = []
+    trainig_losses: list[float | jax.Array] = []
+    validation_losses: list[float | jax.Array] = []
+    eqcvs: list[float | jax.Array] = []
+    ineqcvs: list[float | jax.Array] = []
 
     with (
         Logger(run_name=run_name, project_name="hcnn_toy_mpc") as data_logger,
@@ -268,7 +268,7 @@ def main(
         for step in (pbar := tqdm(range(n_epochs))):
             if g.stop:
                 break
-            epoch_loss: list[jnp.ndarray] = []
+            epoch_loss: list[jax.Array] = []
             batch_sizes: list[int] = []
             start_epoch_time = time.time()
             for batch in train_loader:

--- a/src/benchmarks/toy_SOC/main.py
+++ b/src/benchmarks/toy_SOC/main.py
@@ -50,7 +50,7 @@ else:
 
 
 # %% Projections
-def _project_soc(z: jnp.ndarray) -> jnp.ndarray:
+def _project_soc(z: jax.Array) -> jax.Array:
     """Project onto the second-order cone (SOC) constraint.
 
     Args:
@@ -58,7 +58,7 @@ def _project_soc(z: jnp.ndarray) -> jnp.ndarray:
             Input array of shape (B, m + 1, 1) where the last column is the SOC radius.
 
     Returns:
-        jnp.ndarray:
+        jax.Array:
             Projected array of the same shape as `z`, satisfying the SOC constraint.
     """
     eps = 1e-12
@@ -96,7 +96,7 @@ def rand_sparse_mask(
         dtype: Data type of the tensor. Default is jnp.float64.
 
     Returns:
-        jnp.ndarray:
+        jax.Array:
             A tensor of the specified shape with random values and a mask applied.
     """
     key_val, key_mask = jrnd.split(key)
@@ -122,11 +122,11 @@ def generate_problem(key: jax.Array, batch_size: int):
 
     Returns:
         tuple:
-            - b (jnp.ndarray):
+            - b (jax.Array):
                 Right-hand side of the equality constraints, shape (B, m, 1).
-            - c (jnp.ndarray): Coefficients for the objective function, shape (B, n, 1).
-            - x (jnp.ndarray): Optimal primal solution, shape (B, n, 1).
-            - s (jnp.ndarray):
+            - c (jax.Array): Coefficients for the objective function, shape (B, n, 1).
+            - x (jax.Array): Optimal primal solution, shape (B, n, 1).
+            - s (jax.Array):
                 Optimal dual solution satisfying the SOC constraint, shape (B, m, 1).
     """
     keyz, keyx = jrnd.split(key)
@@ -142,7 +142,7 @@ def generate_problem(key: jax.Array, batch_size: int):
     return b, c, x, s
 
 
-def objective(x: jnp.ndarray, c: jnp.ndarray):
+def objective(x: jax.Array, c: jax.Array):
     """Compute the objective value for the linear problem.
 
     Args:
@@ -150,13 +150,13 @@ def objective(x: jnp.ndarray, c: jnp.ndarray):
         c: Coefficients for the objective function, shape (B, n, 1).
 
     Returns:
-        jnp.ndarray: Objective value, shape (B, 1).
+        jax.Array: Objective value, shape (B, 1).
     """
     return jnp.sum(c * x, axis=(1, 2), keepdims=True)
 
 
 # %% CV and RS
-def constraint_violation_eq(x: jnp.ndarray, s: jnp.ndarray, b: jnp.ndarray):
+def constraint_violation_eq(x: jax.Array, s: jax.Array, b: jax.Array):
     """Compute the constraint violation for Ax = b.
 
     Args:
@@ -165,19 +165,19 @@ def constraint_violation_eq(x: jnp.ndarray, s: jnp.ndarray, b: jnp.ndarray):
         b: Right-hand side of the equality constraints, shape (B, m, 1).
 
     Returns:
-        jnp.ndarray: Constraint violation, shape (B, 1).
+        jax.Array: Constraint violation, shape (B, 1).
     """
     return jnp.linalg.norm(a_dyn @ x + s - b, ord=jnp.inf, axis=-1)
 
 
-def constraint_violation_soc(s: jnp.ndarray):
+def constraint_violation_soc(s: jax.Array):
     """Compute the constraint violation for the SOC constraint.
 
     Args:
         s: Dual solution, shape (B, m + 1, 1).
 
     Returns:
-        jnp.ndarray: Constraint violation, shape (B, 1).
+        jax.Array: Constraint violation, shape (B, 1).
     """
     u = s[:, :-1]
     t = s[:, -1:]
@@ -186,7 +186,7 @@ def constraint_violation_soc(s: jnp.ndarray):
     return jnp.maximum(u_norm - t, 0.0)
 
 
-def relative_suboptimality(x: jnp.ndarray, xstar: jnp.ndarray, c: jnp.ndarray):
+def relative_suboptimality(x: jax.Array, xstar: jax.Array, c: jax.Array):
     """Compute the relative suboptimality of the solution.
 
     Args:
@@ -195,16 +195,14 @@ def relative_suboptimality(x: jnp.ndarray, xstar: jnp.ndarray, c: jnp.ndarray):
         c: Coefficients for the objective function, shape (B, n, 1).
 
     Returns:
-        jnp.ndarray: Relative suboptimality, shape (B, 1).
+        jax.Array: Relative suboptimality, shape (B, 1).
     """
     optimal_val = objective(xstar, c)
     candidate_val = objective(x, c)
     return jnp.abs(candidate_val - optimal_val) / (jnp.abs(optimal_val) + 1e-12)
 
 
-def print_stats(
-    x: jnp.ndarray, s: jnp.ndarray, b: jnp.ndarray, c: jnp.ndarray, xstar: jnp.ndarray
-):
+def print_stats(x: jax.Array, s: jax.Array, b: jax.Array, c: jax.Array, xstar: jax.Array):
     """Print the statistics of the solution.
 
     Args:
@@ -286,7 +284,7 @@ assert a_dyn_aug.shape == (
 a_dyn_aug_inv = jnp.linalg.pinv(a_dyn_aug)
 
 
-def project_pinv_vb(xs: jnp.ndarray, b: jnp.ndarray):
+def project_pinv_vb(xs: jax.Array, b: jax.Array):
     """Project onto the pseudo-inverse of the augmented matrix a_dyn.
 
     Args:
@@ -298,12 +296,12 @@ def project_pinv_vb(xs: jnp.ndarray, b: jnp.ndarray):
             Right-hand side of the equality constraints, shape (B, m, 1).
 
     Returns:
-        jnp.ndarray: Projected array satisfying the equality constraints.
+        jax.Array: Projected array satisfying the equality constraints.
     """
     return xs - a_dyn_aug_inv @ (a_dyn_aug @ xs - b)
 
 
-def step_iteration(yraw: jnp.ndarray, sk: jnp.ndarray, b: jnp.ndarray):
+def step_iteration(yraw: jax.Array, sk: jax.Array, b: jax.Array):
     """Perform one iteration of the forward step.
 
     Args:
@@ -318,7 +316,7 @@ def step_iteration(yraw: jnp.ndarray, sk: jnp.ndarray, b: jnp.ndarray):
             Right-hand side of the equality constraints, shape (B, m, 1).
 
     Returns:
-        jnp.ndarray: Updated governing sequence, shape (B, m + n, 1).
+        jax.Array: Updated governing sequence, shape (B, m + n, 1).
     """
     zk = project_pinv_vb(sk, b)
     reflect = 2 * zk - sk
@@ -329,7 +327,7 @@ def step_iteration(yraw: jnp.ndarray, sk: jnp.ndarray, b: jnp.ndarray):
     return sk + omega * (tk - zk)
 
 
-def step_final(s: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
+def step_final(s: jax.Array, b: jax.Array) -> jax.Array:
     """Retrieve the final result from the forward step.
 
     Args:
@@ -337,16 +335,16 @@ def step_final(s: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
         b: Right-hand side of the equality constraints, shape (B, m, 1).
 
     Returns:
-        jnp.ndarray: Final projected value, shape (B, m + n, 1).
+        jax.Array: Final projected value, shape (B, m + n, 1).
     """
     return project_pinv_vb(s, b)
 
 
 @custom_vjp
 def project(
-    s0: jnp.ndarray,
-    yraw: jnp.ndarray,
-    b: jnp.ndarray,
+    s0: jax.Array,
+    yraw: jax.Array,
+    b: jax.Array,
 ):
     """Project the raw input onto the feasible set defined by the constraints.
 
@@ -357,8 +355,8 @@ def project(
 
     Returns:
         tuple:
-            - zk1 (jnp.ndarray): Projected value, shape (B, m + n, 1).
-            - sk (jnp.ndarray): Final governing sequence, shape (B, m + n, 1).
+            - zk1 (jax.Array): Projected value, shape (B, m + n, 1).
+            - sk (jax.Array): Final governing sequence, shape (B, m + n, 1).
     """
     sk = s0
     sk, _ = lax.scan(
@@ -378,7 +376,7 @@ def project(
     return zk1, sk
 
 
-def _project_fwd(s0: jnp.ndarray, yraw: jnp.ndarray, b: jnp.ndarray):
+def _project_fwd(s0: jax.Array, yraw: jax.Array, b: jax.Array):
     """Forward pass of the projection function.
 
     Args:
@@ -388,8 +386,8 @@ def _project_fwd(s0: jnp.ndarray, yraw: jnp.ndarray, b: jnp.ndarray):
 
     Returns:
         - tuple:
-            - zk1 (jnp.ndarray): Projected value, shape (B, m + n, 1).
-            - sk (jnp.ndarray): Final governing sequence, shape (B, m + n, 1).
+            - zk1 (jax.Array): Projected value, shape (B, m + n, 1).
+            - sk (jax.Array): Final governing sequence, shape (B, m + n, 1).
         - tuple:
             - (sk, yraw, b): Residuals for the backward pass.
     """
@@ -402,21 +400,21 @@ def _project_bwd(residuals: tuple[Any, ...], cotangent: tuple[Any, ...]):
 
     Args:
         residuals: Residuals from the forward pass, containing:
-            - sk (jnp.ndarray): Governing sequence, shape (B, m + n, 1).
-            - yraw (jnp.ndarray): Raw input array, shape (B, m + n, 1).
-            - b (jnp.ndarray):
+            - sk (jax.Array): Governing sequence, shape (B, m + n, 1).
+            - yraw (jax.Array): Raw input array, shape (B, m + n, 1).
+            - b (jax.Array):
                 Right-hand side of the equality constraints, shape (B, m, 1).
 
         cotangent: Cotangent vector from the backward pass, containing:
-            - cotangent_zk1 (jnp.ndarray):
+            - cotangent_zk1 (jax.Array):
                 Cotangent vector for the projected value, shape (B, m + n, 1).
-            - cotangent_sk (jnp.ndarray):
+            - cotangent_sk (jax.Array):
                 Cotangent vector for the governing sequence, shape (B, m + n, 1).
 
     Returns:
         tuple:
             - None: Placeholder for the vjp wrt to sk (the DRA governing sequence).
-            - thevjp (jnp.ndarray):
+            - thevjp (jax.Array):
                 The vjp wrt to yraw, shape (B, m + n, 1).
             - None: Placeholder for the vjp wrt to b
                 (the right-hand side of the equality constraints).
@@ -454,9 +452,7 @@ if use_custom_vjp:
 # project them, and check if the result has no constraint violation.
 
 
-def test_projection(
-    b: jnp.ndarray, c: jnp.ndarray, xstar: jnp.ndarray, sstar: jnp.ndarray
-):
+def test_projection(b: jax.Array, c: jax.Array, xstar: jax.Array, sstar: jax.Array):
     """Test the projection function on random samples.
 
     Args:
@@ -515,7 +511,7 @@ class HardConstrainedMLP(nn.Module):
     @nn.compact
     def __call__(
         self,
-        input: dict[str, jnp.ndarray],
+        input: dict[str, jax.Array],
     ):
         """Call the NN.
 
@@ -524,7 +520,7 @@ class HardConstrainedMLP(nn.Module):
                 Dictionary containing the input data with keys "b" and "c".
 
         Returns:
-            jnp.ndarray:
+            jax.Array:
                 Output of the MLP, projected onto the feasible set.
         """
         b, c = input["b"].squeeze(-1), input["c"].squeeze(-1)
@@ -555,8 +551,8 @@ def make_batch(key: jax.Array, batch_size: int = BATCH_SIZE):
     Returns:
         tuple:
             - dict: Input data containing "b" and "c".
-            - jnp.ndarray: Optimal primal solution, shape (B, n, 1).
-            - jnp.ndarray: Optimal dual solution, shape (B, m, 1).
+            - jax.Array: Optimal primal solution, shape (B, n, 1).
+            - jax.Array: Optimal dual solution, shape (B, m, 1).
     """
     key_prob, key = jrnd.split(key)
     b, c, xstar, sstar = generate_problem(key_prob, batch_size)
@@ -590,7 +586,7 @@ def loss_fn(params: dict[str, Any], input: dict[str, Any]):
 
     Returns:
         tuple:
-            - loss (jnp.ndarray): Mean objective value.
+            - loss (jax.Array): Mean objective value.
             - aux (tuple): Auxiliary values containing constraint violations.
     """
     c = input["c"]
@@ -612,7 +608,7 @@ def train_step(state: train_state.TrainState, batch: dict[str, Any]):
     Returns:
         tuple:
             - state (TrainState): Updated state of the model.
-            - loss (jnp.ndarray): Loss value after the step.
+            - loss (jax.Array): Loss value after the step.
             - aux (tuple): Auxiliary values containing constraint violations.
     """
     grad_fn = value_and_grad(loss_fn, has_aux=True)

--- a/src/tools/autotuning.py
+++ b/src/tools/autotuning.py
@@ -15,6 +15,7 @@ from typing import Any, cast
 
 import jax
 import jax.numpy as jnp
+from jaxtyping import Array, Float
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -31,6 +32,13 @@ from pinet import (
     EquilibrationParams,
     Project,
     ProjectionInstance,
+)
+from pinet._typing import (
+    BatchedEqMatrix,
+    BatchedIneqMatrix,
+    BatchedPrimal,
+    BatchedRHS,
+    BatchedScalar,
 )
 
 jax.config.update("jax_enable_x64", True)
@@ -61,12 +69,12 @@ class LoadedData:
     """
 
     filename: str
-    q: jnp.ndarray
-    p: jnp.ndarray
-    a_dyn: jnp.ndarray
-    constr_matrix: jnp.ndarray
-    h: jnp.ndarray
-    x_dataset: jnp.ndarray
+    q: jax.Array
+    p: jax.Array
+    a_dyn: BatchedEqMatrix
+    constr_matrix: BatchedIneqMatrix
+    h: jax.Array
+    x_dataset: jax.Array
     train_loader: Any
     valid_loader: Any
     test_loader: Any
@@ -144,7 +152,7 @@ def load_data(
         )
         dataset = cast(
             DC3Dataset,
-            cast(DataLoader[tuple[jnp.ndarray, jnp.ndarray]], train_loader).dataset,
+            cast(DataLoader[tuple[jax.Array, jax.Array]], train_loader).dataset,
         )
         q, p, a_dyn, constr_matrix, h = dataset.const
         p = p[0, :, :]
@@ -194,12 +202,12 @@ x_batch = x_batch[:n_samples]
 
 
 def build_evaluate_params(
-    x: jnp.ndarray,
-    b: jnp.ndarray,
+    x: BatchedPrimal,
+    b: BatchedRHS,
     n_iter: int,
-    project: Callable[..., tuple[ProjectionInstance, jnp.ndarray]],
-    compute_cv: Callable[[ProjectionInstance], jnp.ndarray],
-) -> Callable[[jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]]:
+    project: Callable[..., tuple[ProjectionInstance, jax.Array]],
+    compute_cv: Callable[[ProjectionInstance], jax.Array],
+) -> Callable[[jax.Array, jax.Array], tuple[jax.Array, jax.Array, jax.Array]]:
     """Build an evaluator for autotuning hyperparameters.
 
     Args:
@@ -210,9 +218,8 @@ def build_evaluate_params(
         compute_cv: Function computing constraint violation for a projection result.
 
     Returns:
-        Callable[[jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray,
-        jnp.ndarray]]: Function mapping ``(init, sigma)`` to the next warm start,
-        maximum constraint violation, and mean projection distance.
+        Function mapping ``(init, sigma)`` to the next warm start, maximum
+        constraint violation, and mean projection distance.
     """
 
     def evaluate_params(init, sigma):
@@ -251,12 +258,12 @@ omega = 1.7
 
 
 def project(
-    init: jnp.ndarray,
-    x: jnp.ndarray,
-    b: jnp.ndarray,
-    sigma: jnp.ndarray | float,
+    init: jax.Array,
+    x: BatchedPrimal,
+    b: BatchedRHS,
+    sigma: BatchedScalar | float,
     n_iter: int,
-) -> tuple[ProjectionInstance, jnp.ndarray]:
+) -> tuple[ProjectionInstance, jax.Array]:
     """Wrap the projection layer call.
 
     Args:
@@ -267,8 +274,7 @@ def project(
         n_iter: Number of iterations to run.
 
     Returns:
-        tuple[ProjectionInstance, jnp.ndarray]: Projected instance and updated solver
-            state.
+        Projected instance and updated solver state.
     """
     yraw = ProjectionInstance(x=x, eq=EqualityConstraintsSpecification(b=b))
     return projection_layer.call(
@@ -280,14 +286,14 @@ def project(
     )
 
 
-def compute_cv(y: ProjectionInstance) -> jnp.ndarray:
+def compute_cv(y: ProjectionInstance) -> jax.Array:
     """Compute constraint violation.
 
     Args:
         y: Projected instance to evaluate.
 
     Returns:
-        jnp.ndarray: Flattened constraint-violation values.
+        Flattened constraint-violation values.
     """
     # ``projection_layer.cv`` returns ``BatchedScalar`` (ArrayLike) at the
     # public boundary; coerce to ``jax.Array`` for the script's downstream
@@ -335,12 +341,10 @@ eval_fn = jax.jit(build_evaluate_params(x, x_batch, n_iter_step, project, comput
 
 # %%
 def generate_results(
-    sigma_candidates: jnp.ndarray,
+    sigma_candidates: Float[Array, "n_sigma"],
     n_iter_candidates: int,
-    eval_fn: Callable[
-        [jnp.ndarray, jnp.ndarray], tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]
-    ],
-) -> jnp.ndarray:
+    eval_fn: Callable[[jax.Array, jax.Array], tuple[jax.Array, jax.Array, jax.Array]],
+) -> Float[Array, "n_sigma n_iter_candidates 2"]:
     """Evaluate candidate hyperparameters on the validation batch.
 
     Args:
@@ -349,8 +353,8 @@ def generate_results(
         eval_fn: Evaluation function returned by ``build_evaluate_params``.
 
     Returns:
-        jnp.ndarray: Array of shape ``(n_sigma, n_iter_candidates, 2)`` containing
-            the maximum constraint violation and mean projection distance.
+        Array of shape ``(n_sigma, n_iter_candidates, 2)`` containing the maximum
+        constraint violation and mean projection distance.
     """
     # Initialize results array
     results = jnp.inf * jnp.ones((len(sigma_candidates), n_iter_candidates, 2))
@@ -376,12 +380,12 @@ def generate_results(
 
 # %%
 def get_best(
-    results: jnp.ndarray,
-    sigma_candidates: jnp.ndarray,
+    results: Float[Array, "n_sigma n_iter_candidates 2"],
+    sigma_candidates: Float[Array, "n_sigma"],
     n_iter_step: int,
     target_cv: float,
     target_rs: float,
-) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Select the best hyperparameter combination satisfying target metrics.
 
     Args:
@@ -392,8 +396,8 @@ def get_best(
         target_rs: Maximum acceptable relative suboptimality.
 
     Returns:
-        tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]: Best sigma, best iteration
-            count, and the corresponding ``[cv, value]`` result pair.
+        Best sigma, best iteration count, and the corresponding ``[cv, value]``
+        result pair.
 
     Raises:
         ValueError: If no candidate pair satisfies the target conditions.


### PR DESCRIPTION
Re-targets PR #107 to ``dev``. Cherry-pick of ``89ea0d8`` (the single content commit on the original branch) onto current ``dev`` (now at the post-#114 head). Three files (``src/benchmarks/QP/load_qp.py``, ``src/benchmarks/toy_MPC/load_toy_mpc.py``, ``src/tools/autotuning.py``) auto-merged against the slightly-different baseline introduced by #108 — no manual conflict resolution.

Closes [#100](https://github.com/antonioterpin/pinet/issues/100).

## Summary

Extend the jaxtyping rollout from #97 (PR #104) to ``src/tools/`` and ``src/benchmarks/``. After this, ``jnp.ndarray`` is gone from the source tree.

- **``src/tools/`` (small, high leverage):** public function signatures pick up library aliases (``BatchedPrimal``, ``BatchedRHS``, ``BatchedEqMatrix``, ``BatchedIneqMatrix``, ``BatchedScalar``); hyperparameter-tuning helpers use local axis names (``n_sigma``, ``n_iter_candidates``).
- **``src/benchmarks/`` (12 files, 240 occurrences):** mechanical ``jnp.ndarray`` → ``jax.Array`` across ``QP/`` (generate, load, run, parse, plotting), ``toy_MPC/`` (load, model, plotting, run), ``toy_SOC/main.py``, ``model.py``, and ``other_projections.py``. Three files pick up ``import jax`` for the new annotations.
- **Ruff config:** ``[tool.ruff.lint.per-file-ignores]`` gains ``"src/tools/**"`` and ``"src/benchmarks/**"`` entries for ``F722``/``F821`` so quoted jaxtyping strings lint clean.

Benchmark signatures stay on ``jax.Array`` (no jaxtyping aliases) — they're scripts, not a public API.

## Test plan

- [x] ``uv run pytest`` — 588 / 588 pass on the rebased branch.
- [x] ``uv run pre-commit run --all-files`` — to be verified by CI.

## Provenance

Cherry-pick of ``89ea0d8`` onto ``origin/dev`` (``7fb7c72``). The original PR #107 (against ``chore-runtime-typecheck``) can be closed once this lands.