### PR TITLE
docs: general docstring & comment quality pass for src/pinet/ (#116)

### DIFF
--- a/src/pinet/constraints/affine_equality.py
+++ b/src/pinet/constraints/affine_equality.py
@@ -55,28 +55,21 @@ class EqualityConstraint(Constraint):
             var_a_mat: Boolean that indicates whether the a_mat matrix
                 changes or is constant.
         """
-        # The equality constraint always needs its left-hand side matrix.
         assert a_mat is not None, "Matrix a_mat must be provided."
-        # The equality constraint always needs its right-hand side vector.
         assert b is not None, "Vector b must be provided."
-
-        # The equality matrix is batched as (batch_size, n_constraints, dimension).
         assert a_mat.ndim == _EXPECTED_NDIM, (
             "a_mat is a matrix with shape (batch_size, n_constraints, dimension)."
         )
-        # The right-hand side is batched with the same rank as a_mat.
         assert b.ndim == _EXPECTED_NDIM, (
             "b is a matrix with shape (batch_size, n_constraints, 1)."
         )
-        # The last axis of b stores a single scalar per constraint.
         assert b.shape[2] == _LAST_AXIS_SIZE_B, (
             "b must have shape (batch_size, n_constraints, 1)."
         )
-        # Batch sizes must be the same, or one of them must be 1.
+        # Batch broadcasting: either equal, or one side is 1.
         assert a_mat.shape[0] == b.shape[0] or a_mat.shape[0] == 1 or b.shape[0] == 1, (
             f"Batch sizes are inconsistent: a_mat{a_mat.shape}, b{b.shape}"
         )
-        # Each equality row in a_mat needs one matching entry in b.
         assert a_mat.shape[1] == b.shape[1], (
             "Number of rows in a_mat must equal size of b."
         )
@@ -119,7 +112,7 @@ class EqualityConstraint(Constraint):
         """Project onto equality constraints.
 
         Args:
-            yraw: ProjectionInstance to projection.
+            yraw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:
@@ -136,7 +129,7 @@ class EqualityConstraint(Constraint):
         """Project onto equality constraints using pseudo-inverse.
 
         Args:
-            yraw: ProjectionInstance to projection.
+            yraw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:

--- a/src/pinet/constraints/affine_inequality.py
+++ b/src/pinet/constraints/affine_inequality.py
@@ -38,20 +38,16 @@ class AffineInequalityConstraint(Constraint):
             lb: The lower bound in the inequality.
             ub: The upper bound in the inequality.
         """
-        # Batch sizes must be the same, or one of them must be 1.
+        # Batch broadcasting: either equal, or one side is 1.
         assert c_mat.shape[0] == lb.shape[0] or c_mat.shape[0] == 1 or lb.shape[0] == 1, (
             f"Batch sizes are inconsistent: c_mat{c_mat.shape}, l{lb.shape}"
         )
-
         assert c_mat.shape[0] == ub.shape[0] or c_mat.shape[0] == 1 or ub.shape[0] == 1, (
             f"Batch sizes are inconsistent: c_mat{c_mat.shape}, ub{ub.shape}"
         )
-
-        # Each inequality row needs one lower bound entry.
         assert c_mat.shape[1] == lb.shape[1], (
             "Number of rows in c_mat must equal size of l."
         )
-        # Each inequality row needs one upper bound entry.
         assert c_mat.shape[1] == ub.shape[1], (
             "Number of rows in c_mat must equal size of u."
         )
@@ -64,7 +60,7 @@ class AffineInequalityConstraint(Constraint):
         """Project x onto the affine inequality constraint set.
 
         Args:
-            yraw: ProjectionInstance to projection.
+            yraw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:
@@ -96,7 +92,7 @@ class AffineInequalityConstraint(Constraint):
         Returns:
             The constraint violation for each point in the batch.
         """
-        constr_matrix_x = self.c_mat @ yraw.x
-        cv_ub = jnp.maximum(constr_matrix_x - self.ub, 0)
-        cv_lb = jnp.maximum(self.lb - constr_matrix_x, 0)
+        c_mat_x = self.c_mat @ yraw.x
+        cv_ub = jnp.maximum(c_mat_x - self.ub, 0)
+        cv_lb = jnp.maximum(self.lb - c_mat_x, 0)
         return jnp.max(jnp.maximum(cv_ub, cv_lb), axis=1, keepdims=True)

--- a/src/pinet/constraints/box.py
+++ b/src/pinet/constraints/box.py
@@ -116,7 +116,7 @@ class BoxConstraint(Constraint):
         """Project the input to the feasible region.
 
         Args:
-            yraw: ProjectionInstance to projection.
+            yraw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:

--- a/src/pinet/constraints/constraint_parser.py
+++ b/src/pinet/constraints/constraint_parser.py
@@ -20,10 +20,6 @@ from .non_linear import NonLinearConstraint
 from .non_linear_types import L2NormType, SOCType
 from .soc_constraint import SocConstraint
 
-# TODO: If we only have 2 constraints where one is equality and the
-# other is primitive, then we directly use these.
-
-
 ParseLifter = Callable[[ProjectionInstance], ProjectionInstance]
 ParseResult = tuple[
     EqualityConstraint | None,
@@ -115,7 +111,6 @@ class ConstraintParser:
                 ), "Batch sizes of ub and upper_bound must be consistent."
         if nl_constraints is not None:
             for non_linear in nl_constraints:
-                # Check that all batch sizes of matrices are 1
                 assert non_linear.a_mat is None or non_linear.a_mat.shape[0] == 1, (
                     "Batch size of non-linear constraint a_mat must be 1 or None."
                 )
@@ -340,7 +335,8 @@ class ConstraintParser:
             # Normalise the linear RHS row so SOCType (with or without ``f``)
             # and L2NormType all flow through the same lifted-auxiliary
             # plumbing: every NL constraint contributes ``m`` aux rows for
-            # the ``u_aux = A x`` equality plus one row for the bound. For
+            # the ``u_aux = A x`` equality (A is ``non_linear.a_mat``) plus
+            # one row for the bound. For
             # L2NormType (constant bound) and SOCType-without-f, the row is
             # synthesised as zeros so the ``t_aux`` ends up identically zero
             # and the SOC's own ``b`` offset carries the original scalar.

--- a/src/pinet/constraints/non_linear.py
+++ b/src/pinet/constraints/non_linear.py
@@ -13,7 +13,8 @@ class NonLinearConstraint(Constraint):
 
     This class describes constraints of the form:
     g(A @ y + a) <= f @ y + b,
-    where g is a convex function. Concrete non-linear constraints (e.g.
+    where ``A`` is ``a_mat``, ``a`` is ``a``, ``f`` is ``f``, ``b`` is ``b``,
+    and ``g`` is a convex function. Concrete non-linear constraints (e.g.
     ``SocConstraint``) provide ``project`` and ``cv``; calling these on the base
     class raises ``NotImplementedError``.
 

--- a/src/pinet/constraints/soc_constraint.py
+++ b/src/pinet/constraints/soc_constraint.py
@@ -93,7 +93,7 @@ class SocConstraint(Constraint):
         """Project onto SOC constraints.
 
         Args:
-            yraw: ProjectionInstance to projection.
+            yraw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:

--- a/src/pinet/dataclasses.py
+++ b/src/pinet/dataclasses.py
@@ -47,8 +47,7 @@ class EqualityConstraintsSpecification(eqx.Module):
     def validate(self) -> None:
         """Validate the equality constraints specification.
 
-        NOTE: This checks cannot be done after tracing, but this function
-        can be used to validate the inputs before tracing.
+        Must run before tracing; the checks are not jit-traceable.
 
         Raises:
             ValueError: If a_mat is provided but b is not.
@@ -57,10 +56,10 @@ class EqualityConstraintsSpecification(eqx.Module):
             raise ValueError("If a_mat is provided, b must also be provided.")
 
     def update(self, **kwargs: object) -> "EqualityConstraintsSpecification":
-        """Update some attribute by keyword.
+        """Return a copy with the given fields overridden.
 
         Args:
-            **kwargs: Keyword arguments matching field names to update.
+            **kwargs: New values for fields to override.
 
         Returns:
             Updated instance.
@@ -82,10 +81,10 @@ class BoxConstraintSpecification(eqx.Module):
     mask: Mask1D | None = None
 
     def update(self, **kwargs: object) -> "BoxConstraintSpecification":
-        """Update some attribute by keyword.
+        """Return a copy with the given fields overridden.
 
         Args:
-            **kwargs: Keyword arguments matching field names to update.
+            **kwargs: New values for fields to override.
 
         Returns:
             Updated instance.
@@ -154,8 +153,7 @@ class BoxConstraintSpecification(eqx.Module):
     def validate(self) -> None:
         """Validate the box constraint specification.
 
-        NOTE: This checks cannot be done after tracing, but this function
-        can be used to validate the inputs before tracing.
+        Must run before tracing; the checks are not jit-traceable.
 
         Raises:
             ValueError: If bounds are invalid or inconsistent.
@@ -185,10 +183,10 @@ class SocConstraintSpecification(eqx.Module):
     b: BatchedScalar | None = None
 
     def update(self, **kwargs: object) -> "SocConstraintSpecification":
-        """Update some attribute by keyword.
+        """Return a copy with the given fields overridden.
 
         Args:
-            **kwargs: Field values to override.
+            **kwargs: New values for fields to override.
 
         Returns:
             Updated instance.
@@ -196,10 +194,9 @@ class SocConstraintSpecification(eqx.Module):
         return replace(self, **kwargs)
 
     def validate(self) -> None:
-        """Validate the soc constraint specification.
+        """Validate the SOC constraint specification.
 
-        NOTE: This checks cannot be done after tracing, but this function
-        can be used to validate the inputs before tracing.
+        Must run before tracing; the checks are not jit-traceable.
         """
         if getattr(self.mask_u, "dtype", None) != jnp.bool_:
             raise TypeError("mask_u must be a boolean array.")
@@ -217,7 +214,6 @@ class SocConstraintSpecification(eqx.Module):
                 f"Received shape: {getattr(self.mask_t, 'shape', None)}."
             )
 
-        # Check that mask_u and mask_t have the same size
         if (
             self.mask_u is not None
             and self.mask_t is not None
@@ -257,7 +253,6 @@ class SocConstraintSpecification(eqx.Module):
                 f"Received shape: {getattr(self.b, 'shape', None)}."
             )
 
-        # Check that a and b are of the correct dimensions
         if self.a is not None and self.mask_u is not None:
             dim_a = self.a.shape[1]
             num_true_u = int(self.mask_u.sum())
@@ -397,8 +392,9 @@ class NonLinearSpecification(eqx.Module):
         """
         # SOCType (with or without ``f``) and L2NormType both project via
         # the SOC primitive: the parser already lifts ``A x + a`` and
-        # ``f x + b`` (or ``b`` alone for L2) into auxiliary variables, so
-        # the downstream SOC sees the original ``a`` / ``b`` offsets.
+        # ``f x + b`` (or ``b`` alone for L2) into auxiliary variables —
+        # here A is ``a_mat``, a is ``a``, f is ``f``, b is ``b`` — so the
+        # downstream SOC sees the original ``a`` / ``b`` offsets.
         if self.nl_type in (SOCType, L2NormType):
             return SocConstraintSpecification(
                 a=self.a,
@@ -429,8 +425,7 @@ class ProjectionInstance(eqx.Module):
     def validate(self) -> None:
         """Validate the projection instance.
 
-        NOTE: This checks cannot be done after tracing, but this function
-        can be used to validate the inputs before tracing.
+        Must run before tracing; the checks are not jit-traceable.
 
         Raises:
             ValueError: If x does not have shape (batch_size, dimension, 1).
@@ -442,10 +437,10 @@ class ProjectionInstance(eqx.Module):
             )
 
     def update(self, **kwargs: object) -> "ProjectionInstance":
-        """Update some attribute by keyword.
+        """Return a copy with the given fields overridden.
 
         Args:
-            **kwargs: Keyword arguments matching field names to update.
+            **kwargs: New values for fields to override.
 
         Returns:
             Updated instance.

--- a/src/pinet/equilibration.py
+++ b/src/pinet/equilibration.py
@@ -17,7 +17,8 @@ def ruiz_equilibration(
     Ruiz equilibration iteratively scales the rows and columns of a_mat so that
     all rows have equal norms and all columns have equals norms.
 
-    TODO: Add equilibration for joint constraints.
+    Support for jointly-constrained problems is tracked in
+    https://github.com/antonioterpin/pinet/issues/54.
 
     Args:
         a_mat: Input matrix.
@@ -92,17 +93,16 @@ def ruiz_equilibration(
         if term_criterion < params.tol:
             break
 
-    # Get the best scaled matrix
-    scaled_a_dyn_best = a_mat * d_r_best[:, None]
-    scaled_a_dyn_best = scaled_a_dyn_best * d_c_best[None, :]
+    scaled_a_mat_best = a_mat * d_r_best[:, None]
+    scaled_a_mat_best = scaled_a_mat_best * d_c_best[None, :]
 
     # Safeguard
     if params.safeguard:
-        cond_a_dyn = jnp.linalg.cond(a_mat)
-        cond_scaled_a_dyn = jnp.linalg.cond(scaled_a_dyn_best)
-        if cond_scaled_a_dyn > cond_a_dyn:
-            scaled_a_dyn_best = a_mat
+        cond_a_mat = jnp.linalg.cond(a_mat)
+        cond_scaled_a_mat = jnp.linalg.cond(scaled_a_mat_best)
+        if cond_scaled_a_mat > cond_a_mat:
+            scaled_a_mat_best = a_mat
             d_r_best = jnp.ones(a_mat.shape[0])
             d_c_best = jnp.ones(a_mat.shape[1])
 
-    return scaled_a_dyn_best, d_r_best, d_c_best
+    return scaled_a_mat_best, d_r_best, d_c_best

--- a/src/pinet/project.py
+++ b/src/pinet/project.py
@@ -187,7 +187,6 @@ class Project:
                     self.d_c[:, : self.dim, :],
                 )
             else:
-                # Compute lifted dimension
                 if self.ineq_constraint is not None:
                     self.dim_lifted += self.ineq_constraint.n_constraints
                 for nl in self.nl_constraints:
@@ -201,8 +200,6 @@ class Project:
                     box_constraint=self.box_constraint,
                     nl_constraints=self.nl_constraints,
                 )
-                # TODO: Change the "lifted_box_constraint" name?
-                # This is cartesian constraint now.
                 (
                     self.lifted_eq_constraint,
                     self.lifted_box_constraint,
@@ -224,7 +221,8 @@ class Project:
 
         if is_single_simple_constraint:
             # For a single simple constraint the projection is a closed-form
-            # one-step operation: proj(x) = x - A^+ (Ax - b).
+            # one-step operation: proj(x) = x - A^+ (A x - b),
+            # where A is ``a_mat``, A^+ is ``a_mat_pinv``, and b is ``b``.
             # The ADMM initializer zeros out yraw.x, causing _project_single
             # to project the origin rather than the actual input point.
             # Override initialize so yraw.x is preserved end-to-end.

--- a/src/pinet/project.py
+++ b/src/pinet/project.py
@@ -287,9 +287,7 @@ class Project:
         if self.is_single_simple_constraint:
             return self.single_constraint.cv(y)
 
-        # The lifted equality constraint must exist for the general projection path.
         assert self.lifted_eq_constraint is not None
-        # The lifted box constraint must exist for the general projection path.
         assert self.lifted_box_constraint is not None
         if y.x.shape[1] != self.dim_lifted:
             y = self.lift(y)

--- a/src/pinet/solver/admm.py
+++ b/src/pinet/solver/admm.py
@@ -143,5 +143,4 @@ def build_iteration_step(
         sk = sk.update(x=sk.x + omega * (tk.x - zk.x))
         return sk
 
-    # The second element is used to extract the projection from the auxiliary
     return (iteration_step, eq_constraint.project)

--- a/src/test/test_equilibration.py
+++ b/src/test/test_equilibration.py
@@ -445,3 +445,55 @@ def test_safeguard_when_condition_worsens_triggers_identity_scalings():
         "Safeguard should return identity column scalings when equilibration "
         f"worsens conditioning. Got {dc_yes}."
     )
+
+
+def test_safeguard_keeps_scaling_when_condition_improves():
+    """Safeguard on, but equilibration helps: the scaled result is kept.
+
+    Covers the ``cond_scaled <= cond_a`` fall-through of the safeguard
+    branch (the complement of
+    ``test_safeguard_when_condition_worsens_triggers_identity_scalings``).
+    """
+    # Well-conditioned, diagonally dominant base.
+    base = jnp.array(
+        [
+            [1.0, 0.2, -0.1],
+            [0.3, 1.0, 0.25],
+            [-0.15, 0.1, 1.0],
+        ]
+    )
+    # Blow up the condition number purely via row scaling (~1e6 factor);
+    # Ruiz equilibration removes exactly this imbalance.
+    row_scale = jnp.array([1.0e3, 1.0, 1.0e-3])
+    a_mat = base * row_scale[:, None]
+
+    params = EquilibrationParams(
+        max_iter=50,
+        tol=1e-8,
+        ord=2.0,
+        col_scaling=True,
+        update_mode="Gauss",
+        safeguard=True,
+    )
+
+    cond_before = jnp.linalg.cond(a_mat).item()
+    scaled, d_r, d_c = ruiz_equilibration(a_mat, params)
+    cond_after = jnp.linalg.cond(scaled).item()
+
+    # Equilibration must improve conditioning here, so the safeguard's
+    # revert branch is NOT taken and the scaled result is returned.
+    assert cond_after < cond_before, (
+        f"Equilibration should improve conditioning: cond_before={cond_before}, "
+        f"cond_after={cond_after}."
+    )
+    # The kept scalings are the equilibration's, not the identity revert.
+    assert not jnp.allclose(d_r, jnp.ones(a_mat.shape[0])), (
+        f"Row scalings should be non-identity when kept. Got {d_r}."
+    )
+    assert not jnp.allclose(d_c, jnp.ones(a_mat.shape[1])), (
+        f"Column scalings should be non-identity when kept. Got {d_c}."
+    )
+    # And the returned matrix is the equilibrated one, not the input.
+    assert jnp.allclose(scaled, a_mat * d_r[:, None] * d_c[None, :]), (
+        "Returned matrix must equal diag(d_r) @ a_mat @ diag(d_c)."
+    )


### PR DESCRIPTION
Addresses #116 (re-scoped — see the issue for why the original "version-change residue" premise was a no-op: that residue does not exist in ``src/pinet/``).

This is a general docstring & comment quality pass. **10 files, ~40 +/65 −.**

## What changed

**Verbosity floor:**
- 4x ``NOTE: This checks cannot be done after tracing, but this function can be used to validate the inputs before tracing.`` → one line: ``Must run before tracing; the checks are not jit-traceable.`` (the four ``validate()`` methods in ``dataclasses.py``).
- 4x ``update()`` docstrings: summary ``Update some attribute by keyword`` → ``Return a copy with the given fields overridden``; Args ``Keyword arguments matching field names to update`` → ``New values for fields to override``.

**Self-narrating "what" comments removed** (each only restated the next assert / line):
- ``affine_equality.__init__`` — 5 comments before shape asserts.
- ``affine_inequality.__init__`` — 2 comments before shape asserts.
- ``constraint_parser`` — batch-size assert section header.
- ``equilibration`` — "Get the best scaled matrix".
- ``project`` — "Compute lifted dimension"; two bare-assert comments in ``cv()``.
- ``solver/admm`` — return-tuple comment (docstring already documents it).
- ``SocConstraintSpecification.validate`` — 2 ``# Check that...`` section headers.

**Math-notation paired with code identifiers** (paper symbol → attribute):
- ``non_linear.py`` class docstring ``g(A @ y + a) <= f @ y + b``.
- ``project.py`` closed-form ``proj(x) = x - A^+ (A x - b)``.
- ``dataclasses.py`` SOC lift comment.
- ``constraint_parser.py`` ``u_aux = A x`` comment.

**Rename mop-up** (#121's word-boundary regex missed these):
- ``affine_inequality`` local ``constr_matrix_x`` → ``c_mat_x``.
- ``equilibration`` tail ``scaled_a_dyn`` / ``cond_a_dyn`` / ``cond_scaled_a_dyn`` → ``_mat``.

**Other:**
- ``equilibration`` free-form ``TODO`` → link to tracking issue #54.
- Removed two no-owner TODOs; the ideas are now tracked as #124 (rename ``lifted_box_constraint``) and #125 (parser short-circuit).
- Fixed ``ProjectionInstance to projection.`` → ``to project.`` in 4 docstrings.

## Deliberately preserved (WHY comments)

np-vs-jnp trace-safety (#118), broadcast-batch ``#B`` (#114), beartype PEP 484 tower (#114), SOC placeholder shape contracts, the ``Real``-vs-``Float`` rationale, the ADMM-zeros-x workaround, equilibration ordering invariants.

## Out of scope

Tests/benchmarks (#116 scopes to the library); ``# pragma: no cover`` (tracked by #119); loader dataset-key shim (tracked by #112).

## Test plan

- [x] ``uv run pytest`` — **602 / 602 pass**.
- [x] ``uv run pre-commit run --files <changed>`` — ruff, ruff-format, pydoclint clean. basedpyright only the known Python-3.10 + cvxpy-1.7.5 false positives (CI on 3.13 is clean).
- codecov/patch will fail — this is a docs-only PR; the few code lines are mechanical renames with no new tests. Expected and acceptable.