### PR TITLE
chore(parser): drop unreachable defensive raises, consolidate type guard

### DIFF
--- a/src/pinet/constraints/constraint_parser.py
+++ b/src/pinet/constraints/constraint_parser.py
@@ -17,7 +17,6 @@ from .affine_inequality import AffineInequalityConstraint
 from .box import BoxConstraint
 from .cartesian_constraint import CartesianConstraint
 from .non_linear import NonLinearConstraint
-from .non_linear_types import L2NormType, SOCType
 from .soc_constraint import SocConstraint
 
 ParseLifter = Callable[[ProjectionInstance], ProjectionInstance]
@@ -336,22 +335,19 @@ class ConstraintParser:
             # and L2NormType all flow through the same lifted-auxiliary
             # plumbing: every NL constraint contributes ``m`` aux rows for
             # the ``u_aux = A x`` equality (A is ``non_linear.a_mat``) plus
-            # one row for the bound. For
-            # L2NormType (constant bound) and SOCType-without-f, the row is
-            # synthesised as zeros so the ``t_aux`` ends up identically zero
-            # and the SOC's own ``b`` offset carries the original scalar.
-            if non_linear.nl_type in (SOCType, L2NormType):
-                f_row: ArrayLike = (
-                    non_linear.f
-                    if non_linear.f is not None
-                    else jnp.zeros((1, 1, non_linear.a_mat.shape[2]))
-                )
-                all_matrices.append(f_row)
-                dims[-1] += 1
-            else:  # pragma: no cover -- defended by NonLinearSpecification._validate_type
-                raise ValueError(
-                    f"Unsupported non-linear constraint type: {type(non_linear.nl_type)}"
-                )
+            # one row for the bound. For L2NormType (constant bound) and
+            # SOCType-without-f, the row is synthesised as zeros so the
+            # ``t_aux`` ends up identically zero and the SOC's own ``b``
+            # offset carries the original scalar. ``nl_type`` is guaranteed
+            # supported by ``NonLinearSpecification._validate_type`` (run at
+            # ``NonLinearConstraint`` construction), so no type guard here.
+            f_row: ArrayLike = (
+                non_linear.f
+                if non_linear.f is not None
+                else jnp.zeros((1, 1, non_linear.a_mat.shape[2]))
+            )
+            all_matrices.append(f_row)
+            dims[-1] += 1
         # Dimension of auxiliary variables. ``dims`` is a Python list of
         # ``int`` shape values, so use the built-in ``sum`` to avoid
         # producing a traced array inside ``jnp.sum`` (which would error
@@ -449,35 +445,35 @@ class ConstraintParser:
         for nl in nl_constraints:
             # Non-linear constraints need a linear-transformation matrix for lifting.
             assert nl.a_mat is not None
-            if nl.nl_type in (SOCType, L2NormType):
-                # Masks depend only on (static) dimensions, not on traced
-                # tensor values. Build them as ``numpy`` arrays so the
-                # downstream ``validate()`` (which calls ``.sum()``) returns
-                # a concrete Python scalar — important when
-                # ``parse_non_linear`` is re-invoked from the jitted
-                # ``solver.admm.initialize`` for ``var_a_mat=True``.
-                socspec = SocConstraintSpecification(
-                    mask_u=np.array(
-                        [False] * n_curr
-                        + [True] * nl.a_mat.shape[1]
-                        + [False] * (n_tot - n_curr - nl.a_mat.shape[1]),
-                        dtype=np.bool_,
-                    ),
-                    mask_t=np.array(
-                        [False] * (n_curr + nl.a_mat.shape[1])
-                        + [True]
-                        + [False] * (n_tot - n_curr - nl.a_mat.shape[1] - 1),
-                        dtype=np.bool_,
-                    ),
-                    a=nl.a,
-                    b=nl.b,
-                )
-                prim_constraints.append(SocConstraint(socspec=socspec))
-                n_curr += nl.a_mat.shape[1] + 1
-            else:  # pragma: no cover -- defended by NonLinearSpecification._validate_type
-                raise ValueError(
-                    f"Unsupported non-linear constraint type: {type(nl.nl_type)}"
-                )
+            # ``nl_type`` is guaranteed supported by
+            # ``NonLinearSpecification._validate_type`` (run at
+            # ``NonLinearConstraint`` construction). SOCType and L2NormType
+            # both lower to the same SocConstraint; the difference is carried
+            # by the synthesised f-row in the equality block above.
+            # Masks depend only on (static) dimensions, not on traced
+            # tensor values. Build them as ``numpy`` arrays so the
+            # downstream ``validate()`` (which calls ``.sum()``) returns
+            # a concrete Python scalar — important when
+            # ``parse_non_linear`` is re-invoked from the jitted
+            # ``solver.admm.initialize`` for ``var_a_mat=True``.
+            socspec = SocConstraintSpecification(
+                mask_u=np.array(
+                    [False] * n_curr
+                    + [True] * nl.a_mat.shape[1]
+                    + [False] * (n_tot - n_curr - nl.a_mat.shape[1]),
+                    dtype=np.bool_,
+                ),
+                mask_t=np.array(
+                    [False] * (n_curr + nl.a_mat.shape[1])
+                    + [True]
+                    + [False] * (n_tot - n_curr - nl.a_mat.shape[1] - 1),
+                    dtype=np.bool_,
+                ),
+                a=nl.a,
+                b=nl.b,
+            )
+            prim_constraints.append(SocConstraint(socspec=socspec))
+            n_curr += nl.a_mat.shape[1] + 1
 
         cartesian_lifted = CartesianConstraint(
             box_constraint=box_lifted, nl_constraints=prim_constraints

--- a/src/pinet/dataclasses.py
+++ b/src/pinet/dataclasses.py
@@ -329,10 +329,14 @@ class NonLinearSpecification(eqx.Module):
                 "L2NormType with RHS (f) is not supported in NonLinearSpecification. "
                 "Use SOCType instead."
             )
-        if not isinstance(self.nl_type, NonLinearConstraintType):
+        # Single owner of the "which nl_type the library supports" invariant.
+        # The parser and to_primitive_spec rely on this: any spec that passes
+        # validate() is guaranteed to carry a supported type, so they need no
+        # parallel guard. A future NonLinearConstraintType member is rejected
+        # here at construction instead of being silently mis-projected.
+        if self.nl_type not in (SOCType, L2NormType):
             raise ValueError(
-                f"nl_type must be a NonLinearConstraintType instance, "
-                f"got {type(self.nl_type)}"
+                f"nl_type must be SOCType or L2NormType, got {self.nl_type!r}."
             )
 
     def _validate_batch_sizes(self) -> None:
@@ -388,21 +392,15 @@ class NonLinearSpecification(eqx.Module):
             Equivalent primitive constraint spec.
 
         Raises:
-            NotImplementedError: If the non-linear type is not supported.
+            ValueError: If ``nl_type`` is not a supported type.
         """
+        self._validate_type()
         # SOCType (with or without ``f``) and L2NormType both project via
         # the SOC primitive: the parser already lifts ``A x + a`` and
         # ``f x + b`` (or ``b`` alone for L2) into auxiliary variables —
         # here A is ``a_mat``, a is ``a``, f is ``f``, b is ``b`` — so the
         # downstream SOC sees the original ``a`` / ``b`` offsets.
-        if self.nl_type in (SOCType, L2NormType):
-            return SocConstraintSpecification(
-                a=self.a,
-                b=self.b,
-            )
-        raise NotImplementedError(  # pragma: no cover -- defended by _validate_type
-            f"Conversion to primitive spec not implemented for nl_type {self.nl_type}"
-        )
+        return SocConstraintSpecification(a=self.a, b=self.b)
 
 
 class ProjectionInstance(eqx.Module):

--- a/src/test/test_dataclasses.py
+++ b/src/test/test_dataclasses.py
@@ -485,6 +485,24 @@ def test_nonlinear_validate_nl_type_must_be_constraint_type_instance():
         spec.validate()
 
 
+def test_validate_type_rejects_unsupported_nl_type_post_construction():
+    """``_validate_type`` is the single owner of the supported-set
+    invariant: the parser and ``to_primitive_spec`` rely on it and carry no
+    guard of their own.
+
+    The nl_type is corrupted *after* construction so beartype (hook on by
+    default) does not pre-empt at the constructor; this exercises the
+    reachable ``nl_type not in (SOCType, L2NormType)`` raise in-process.
+    """
+    spec = NonLinearSpecification(nl_type=SOCType, a_mat=jnp.ones((1, 2, 3)))
+    object.__setattr__(spec, "nl_type", cast(object, "not_a_real_type"))
+    with pytest.raises(ValueError, match=r"SOCType or L2NormType"):
+        spec.validate()
+    # to_primitive_spec routes through the same guard.
+    with pytest.raises(ValueError, match=r"SOCType or L2NormType"):
+        spec.to_primitive_spec()
+
+
 def test_nonlinear_validate_inconsistent_batch_sizes_raises():
     with pytest.raises(_ShapeOrValidationError):
         spec = NonLinearSpecification(
@@ -579,7 +597,10 @@ def test_nonlinear_validate_b_is_not_a_scalar():
 
 
 def test_nonlinear_to_primitive_spec_with_invalid_type():
-    with pytest.raises((NotImplementedError, TypeCheckError)):
+    # to_primitive_spec validates the type up front: an unsupported nl_type
+    # fails via _validate_type (ValueError) or, with PINET_RUNTIME_CHECK=1,
+    # is rejected by beartype at construction (TypeCheckError).
+    with pytest.raises((ValueError, TypeCheckError)):
         spec = NonLinearSpecification(
             nl_type=cast(NonLinearConstraintType, cast(object, "invalid_type")),
             a_mat=jnp.ones((1, 2, 3)),

--- a/src/test/test_parser_and_nonlinear.py
+++ b/src/test/test_parser_and_nonlinear.py
@@ -8,7 +8,6 @@ import jax.random as jrnd
 import numpy as np
 import pytest
 from cvxpy.constraints.constraint import Constraint as CvxpyConstraint
-from jaxtyping import TypeCheckError
 
 from pinet import (
     AffineInequalityConstraint,
@@ -418,43 +417,6 @@ def test_parse_non_linear_l2_norm_projection(seed: int, batch_size: int):
         f"L2 norm bound violated after projection: max={float(jnp.max(norms))}, "
         f"bound={float(b_l2[0, 0, 0])}"
     )
-
-
-def test_parse_non_linear_irrelevant_type_raises_value_error():
-    """Test parser raises for unsupported nonlinear type value."""
-    a_mat = jnp.array([[[1.0, 0.0]]])
-    b = jnp.array([[[0.0]]])
-    c_mat = jnp.array([[[1.0, 0.0]]])
-    lb = jnp.array([[[-1.0]]])
-    ub = jnp.array([[[1.0]]])
-
-    eq_constraint = EqualityConstraint(a_mat=a_mat, b=b, var_b=False)
-    ineq_constraint = AffineInequalityConstraint(c_mat=c_mat, lb=lb, ub=ub)
-
-    nl_spec = NonLinearSpecification(
-        nl_type=SOCType,
-        a_mat=jnp.array([[[1.0, 0.0]]]),
-        a=jnp.zeros((1, 1, 1)),
-        f=jnp.array([[[0.0, 1.0]]]),
-        b=jnp.ones((1, 1, 1)),
-    )
-    nl_constraint = NonLinearConstraint(spec=nl_spec)
-    # Deliberately monkey-patch an invalid type to exercise the parser's error path.
-    object.__setattr__(nl_constraint, "_nl_type", "irrelevant_type")
-
-    parser = ConstraintParser(
-        eq_constraint=eq_constraint,
-        ineq_constraint=ineq_constraint,
-        box_constraint=None,
-        nl_constraints=[nl_constraint],
-    )
-
-    # With ``PINET_RUNTIME_CHECK=1`` beartype catches the invalid nl_type at
-    # the property's return-value check before the parser runs; otherwise
-    # the parser raises ValueError with the documented message. Either path
-    # is acceptable.
-    with pytest.raises((ValueError, TypeCheckError)):
-        parser.parse()
 
 
 def test_parse_non_linear_with_ineq_batch_size_not_one_raises():


### PR DESCRIPTION
Closes #119.

#119 asked to delete the three ``# pragma: no cover`` defensive raises. Its stated premise — "``_validate_type`` is the sole owner of that invariant" — was **not actually true**: ``_validate_type`` only checked ``isinstance(nl_type, NonLinearConstraintType)``, which is equivalent to "is a supported type" *only by accident* (the enum has exactly two members today). A future enum member would have passed validation and then been silently mis-projected by the unconditional parser. So the correct fix is to first make the invariant genuinely owned, then remove the now-provably-dead raises.

## Changes

**``NonLinearSpecification._validate_type``** — now checks ``nl_type not in (SOCType, L2NormType)`` instead of the ``isinstance`` check. Single, forward-safe owner: any spec that passes ``validate()`` is guaranteed to carry a supported type; a future ``NonLinearConstraintType`` member fails loudly here at construction instead of silently mis-projecting.

**``parse_non_linear``** — both ``if nl_type in (SOCType, L2NormType): ... else: raise`` guards dropped; bodies unconditional. Every ``NonLinearConstraint`` is validated at construction, so the type is guaranteed supported by the time the parser runs. Removed the now-unused ``SOCType``/``L2NormType`` import.

**``to_primitive_spec``** — calls ``self._validate_type()`` up front, then unconditionally returns. Trailing ``raise NotImplementedError`` + the stale ``Raises: NotImplementedError`` docstring removed (now ``Raises: ValueError``). It is now self-defending even if called on a spec that bypassed ``NonLinearConstraint.__init__``.

**No ``# pragma: no cover`` remains anywhere under ``src/pinet/``.**

## Tests

- Deleted ``test_parse_non_linear_irrelevant_type_raises_value_error`` — it monkey-patched ``_nl_type`` to reach the now-removed dead parser branch. The reachable equivalent is already covered by ``test_nonlinear_validate_nl_type_must_be_constraint_type_instance``.
- Added ``test_validate_type_rejects_unsupported_nl_type_post_construction`` — corrupts ``nl_type`` *after* construction (so beartype, hook-on by default, does not pre-empt) and asserts both ``validate()`` and ``to_primitive_spec()`` raise ``ValueError`` via the consolidated guard. In-process (a subprocess test would not move coverage — pytest-cov does not instrument child processes), so the new raise is genuinely covered, not silenced.
- Updated ``test_nonlinear_to_primitive_spec_with_invalid_type`` expected exception ``NotImplementedError`` -> ``ValueError``.

## Test plan

- [x] ``uv run pytest`` — **603 / 603 pass**.
- [x] ``uv run pre-commit run --files <changed>`` — ruff, ruff-format, pydoclint clean. basedpyright only the known Python-3.10 + cvxpy-1.7.5 false positives (CI on 3.13 is clean).
- [x] Branch coverage verified: the new ``_validate_type`` raise (was line 338) is now hit in-process; ``equilibration``-style codecov trap avoided.

## Note on ordering

Independent of #123 (docstring pass) — different sites. Mergeable on its own onto current ``dev``.