### PR TITLE
refactor(naming): rename Project.lifted_box_constraint -> lifted_primitive_constraint (closes #124)

### DIFF
--- a/src/pinet/constraints/constraint_parser.py
+++ b/src/pinet/constraints/constraint_parser.py
@@ -132,7 +132,7 @@ class ConstraintParser:
                 Valid methods are "pinv", and None.
 
         Returns:
-            A tuple (eq_constraint, constraint_set, lift_function).
+            A tuple (eq_constraint, primitive_constraint, lift_function).
         """
         if self._identity_mode:
             return (self.eq_constraint, self.box_constraint, lambda y: y)
@@ -149,7 +149,7 @@ class ConstraintParser:
             method: Method to use for solving linear systems.
 
         Returns:
-            A tuple (lifted_eq_constraint, lifted_box_constraint, lift_function).
+            A tuple (lifted_eq_constraint, lifted_primitive_constraint, lift_function).
         """
         ineq_constraint = self.ineq_constraint
         # Precondition: the polytope path requires an inequality constraint.

--- a/src/pinet/project.py
+++ b/src/pinet/project.py
@@ -119,11 +119,11 @@ class Project:
                     ineq_constraint=self.ineq_constraint,
                     box_constraint=self.box_constraint,
                 )
-                (parsed_eq, parsed_box, self.lift) = parser.parse(method=None)
+                (parsed_eq, parsed_primitive, self.lift) = parser.parse(method=None)
                 # Inequality-constrained parsing must yield a lifted equality.
                 assert parsed_eq is not None
-                # Inequality-constrained parsing must yield a lifted box.
-                assert parsed_box is not None
+                # Inequality-constrained parsing must yield a lifted primitive.
+                assert parsed_primitive is not None
                 # Setup always stores equilibration parameters before this branch runs.
                 assert self.equilibration_params is not None
                 # Only equilibrate when we have a single a_mat.
@@ -161,28 +161,28 @@ class Project:
                     var_a_mat=parsed_eq.var_a_mat,
                 )
 
-                # Scale the lifted box constraints.
+                # Scale the lifted primitive constraint.
                 # The polytope path always produces a BoxConstraint (not a cartesian).
-                assert isinstance(parsed_box, BoxConstraint)
+                assert isinstance(parsed_primitive, BoxConstraint)
                 # BoxConstraint.__init__ guarantees mask/lb/ub are set.
-                assert parsed_box.mask is not None
-                assert parsed_box.lb is not None
-                assert parsed_box.ub is not None
-                mask = parsed_box.mask
+                assert parsed_primitive.mask is not None
+                assert parsed_primitive.lb is not None
+                assert parsed_primitive.ub is not None
+                mask = parsed_primitive.mask
                 box_scale = 1 / self.d_c[:, mask, :]
 
-                self.lifted_box_constraint = BoxConstraint(
+                self.lifted_primitive_constraint = BoxConstraint(
                     BoxConstraintSpecification(
-                        lb=parsed_box.lb * box_scale,
-                        ub=parsed_box.ub * box_scale,
-                        mask=parsed_box.mask,
+                        lb=parsed_primitive.lb * box_scale,
+                        ub=parsed_primitive.ub * box_scale,
+                        mask=parsed_primitive.mask,
                     ),
                     scale=box_scale,
                 )
 
                 self.step_iteration, self.step_final = build_iteration_step(
                     self.lifted_eq_constraint,
-                    self.lifted_box_constraint,
+                    self.lifted_primitive_constraint,
                     self.dim,
                     self.d_c[:, : self.dim, :],
                 )
@@ -202,19 +202,19 @@ class Project:
                 )
                 (
                     self.lifted_eq_constraint,
-                    self.lifted_box_constraint,
+                    self.lifted_primitive_constraint,
                     self.lift,
                 ) = parser.parse(method="pinv")
                 # The non-linear path must produce a lifted equality and a cartesian.
                 assert self.lifted_eq_constraint is not None
-                assert self.lifted_box_constraint is not None
+                assert self.lifted_primitive_constraint is not None
                 # Impose no rescaling
                 self.d_r = jnp.ones((1, self.lifted_eq_constraint.a_mat.shape[1], 1))
                 self.d_c = jnp.ones((1, self.dim_lifted, 1))
 
                 self.step_iteration, self.step_final = build_iteration_step(
                     eq_constraint=self.lifted_eq_constraint,
-                    box_constraint=self.lifted_box_constraint,
+                    box_constraint=self.lifted_primitive_constraint,
                     dim=self.dim,
                     scale=self.d_c[:, : self.dim, :],
                 )
@@ -288,12 +288,12 @@ class Project:
             return self.single_constraint.cv(y)
 
         assert self.lifted_eq_constraint is not None
-        assert self.lifted_box_constraint is not None
+        assert self.lifted_primitive_constraint is not None
         if y.x.shape[1] != self.dim_lifted:
             y = self.lift(y)
         return jnp.maximum(
             self.lifted_eq_constraint.cv(y),
-            self.lifted_box_constraint.cv(y),
+            self.lifted_primitive_constraint.cv(y),
         )
 
     def call_and_check(

--- a/src/test/test_project.py
+++ b/src/test/test_project.py
@@ -420,10 +420,10 @@ def test_project_cv_linear_constraints(seed):
     y_lifted = layer.lift(yraw)
     # The non-simple polytope path always populates these lifted attributes.
     assert layer.lifted_eq_constraint is not None
-    assert layer.lifted_box_constraint is not None
+    assert layer.lifted_primitive_constraint is not None
     cv_expected = jnp.maximum(
         layer.lifted_eq_constraint.cv(y_lifted),
-        layer.lifted_box_constraint.cv(y_lifted),
+        layer.lifted_primitive_constraint.cv(y_lifted),
     )
 
     assert jnp.allclose(cv_layer, cv_expected)
@@ -481,10 +481,10 @@ def test_project_cv_nonlinear_constraints(seed):
     y_lifted = layer.lift(yraw)
     # The non-linear path always populates these lifted attributes.
     assert layer.lifted_eq_constraint is not None
-    assert layer.lifted_box_constraint is not None
+    assert layer.lifted_primitive_constraint is not None
     cv_expected = jnp.maximum(
         layer.lifted_eq_constraint.cv(y_lifted),
-        layer.lifted_box_constraint.cv(y_lifted),
+        layer.lifted_primitive_constraint.cv(y_lifted),
     )
 
     assert jnp.allclose(cv_layer, cv_expected)


### PR DESCRIPTION
Closes #124.

`Project.lifted_box_constraint` was misnamed: it holds the **primitive, directly-projectable half of the lifted Douglas–Rachford split** — a `BoxConstraint` on the polytope path, a `CartesianConstraint` (box × SOC × …) on the non-linear path. "Box" was a leftover from the polytope-only design.

Renamed to **`lifted_primitive_constraint`** — "primitive" is the project's existing vocabulary for closed-form-projectable constraints (README NonLinearConstraint section, #125), and it pairs cleanly with `lifted_eq_constraint` (the affine half).

## Changes (pure rename, no behavior change)

- `Project.lifted_box_constraint` → `lifted_primitive_constraint`
- local `parsed_box` → `parsed_primitive` in `Project.setup`
- assertion / scaling comments updated
- `ConstraintParser` docstrings: aligned the tuple slot to `primitive_constraint` / `lifted_primitive_constraint` (previously inconsistent: `:135` said `constraint_set`, `:152` said `lifted_box_constraint`)
- `test_project.py` references updated

Diff is symmetric **25 insertions / 25 deletions** across 3 files.

## Validation

- `uv run pytest`: **603 passed**, 6 deselected
- ruff / ruff format / pydoclint: pass; `basedpyright` 0 errors on changed files
- (The 3 pre-existing `basedpyright` errors on `dev` in `other_projections.py` / `_typing.py` / `test_equilibration.py` are untouched by this PR — not a regression.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)