### PR TITLE
chore: address PR #129 review comments

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# PiNet development
+# Pinet development
 
 All documentation is centralized in `docs/`. Claude will discover what it needs based on your task.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Pinet project instructions
+
+This is a thin wrapper. The single source of truth for all rules, workflows,
+and procedures is the [`docs/`](../docs/) folder — read it, do not duplicate it
+here.
+
+## Project rules
+
+All code must satisfy the standards in [docs/standards/](../docs/standards/):
+
+- [Environment & Tooling](../docs/standards/environment-tooling.md) — always use `uv run`
+- [Code Quality Gates](../docs/standards/code-quality.md)
+- [Linting & Formatting](../docs/standards/linting-formatting.md)
+- [Typing & Docstrings](../docs/standards/typing-docstrings.md)
+- [Code Clarity](../docs/standards/code-clarity.md)
+- [Naming](../docs/standards/naming.md)
+- [Exploration & Validation](../docs/standards/exploration-validation.md)
+- [ML & Numerical Code](../docs/standards/ml-numerical.md)
+- [Testing Policy](../docs/standards/testing.md)
+- [API Design](../docs/standards/api-design.md)
+- [Version Control](../docs/standards/version-control.md)
+- [Code Organization](../docs/standards/code-organization.md)
+- [Change Scope](../docs/standards/change-scope.md)
+- [Device Utilization](../docs/standards/device-utilization.md)
+
+## Quick start
+
+1. **Orientation**: see [docs/workflows/orientation.md](../docs/workflows/orientation.md).
+2. **Workflows**: pick the matching one from [docs/workflows/](../docs/workflows/).
+
+See [docs/index.md](../docs/index.md) for the complete documentation index and
+[CONTRIBUTING.md](../CONTRIBUTING.md) for human-facing development setup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,144 +1,128 @@
 # Contributing
 
-
+- [Development setup](#development-setup)
 - [Development workflow](#development-workflow)
 - [Testing a feature](#testing-a-feature)
+- [Quality gates](#quality-gates)
 - [Preparing for a PR](#preparing-for-a-pr)
-We will use [conda](https://conda.io/en/latest/user-guide/install/) to handle the virtual environment for development.
+
+All project rules, standards, and step-by-step workflows live in
+[`docs/`](docs/) — start at [`docs/index.md`](docs/index.md). This file
+covers human-facing setup and the contribution workflow only.
+
+## Development setup
+
+We use [`uv`](https://docs.astral.sh/uv/) to manage the virtual environment
+and dependencies. [Install `uv`](https://docs.astral.sh/uv/getting-started/installation/),
+then sync the environment from the lockfile:
+
 ```sh
-conda create -n pinet python=3.10
-conda activate pinet
+# Runtime + dev dependencies (pre-commit, pytest, basedpyright, ruff, ...)
+uv sync --extra dev
+
+# Add the CUDA 12 wheels as well if you have a GPU
+uv sync --extra dev --extra cuda12
 ```
 
-To install the requirements, run:
-```sh
-pip install pip --upgrade
-pip install -e .[dev,cuda12]
-```
-To not install cuda related things, just omit it.
+`uv run <command>` runs a command inside the managed environment; never
+assume a global install. Add dependencies with `uv add <package>` (runtime)
+or `uv add --dev <package>` (dev only) — do not hand-edit `pyproject.toml`,
+and commit the updated `uv.lock`.
 
-**Note**: The above command works with bash. For, e.g., zsh interpreter you need the quotes:
-```sh
-pip install pip --upgrade
-pip install -e ".[dev]"
-```
-To not install cuda related things, just omit it.
+Install the git hooks (pre-commit, pre-push, and commit-msg are all
+configured):
 
-The `Coding style validation` action will fail if the pre-commit checks do not pass. To make sure that these are checked automatically on push, run:
 ```sh
-pre-commit install --hook-type pre-push
+uv run pre-commit install --install-hooks
 ```
-To run the pre-commit checks on specific files:
-```bash
-pre-commit run --files <files>
-```
-If for some reason you really want to ignore them during commit/push, add `--no-verify`.
 
-To ease writing commit messages that conform to the [standard](https://www.conventionalcommits.org/en/v1.0.0/#summary), you can configure the template with:
-```bash
+To configure the Conventional Commits message template:
+
+```sh
 git config commit.template .gitmessage
 ```
-To fill in the template, run
-```bash
-git commit
+
+## Development workflow
+
+We follow a [Git feature-branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow)
+workflow with test-driven development:
+
+1. Open an issue describing the goal and the tests that must pass for it to
+   be considered done.
+2. Branch from `dev`:
+   ```sh
+   git checkout dev
+   git checkout -b <type>-<short-description>
+   ```
+3. Write the tests first (see [Testing a feature](#testing-a-feature) and
+   [docs/standards/testing.md](docs/standards/testing.md)).
+4. Implement until the tests pass and all [quality gates](#quality-gates)
+   are green.
+5. Open a PR to `dev` (squashed to a single Conventional-Commits commit).
+6. Delete the branch once merged.
+
+- `main` and `dev` are protected and require a PR.
+- CI runs the [code-style](.github/workflows/code-style.yaml),
+  [commit-lint](.github/workflows/commitlint.yaml), and
+  [tests](.github/workflows/test.yaml) workflows on every push, so the state
+  of each feature is visible without polling the author.
+- A PR to `main` is opened only for milestones (a `dev → main` release).
+
+Pick the workflow that matches your task from
+[`docs/workflows/`](docs/workflows/) (feature, bugfix, refactor,
+api-validation, docs); first-timers should start with
+[`docs/workflows/orientation.md`](docs/workflows/orientation.md).
+
+## Testing a feature
+
+Add a `test_<area>.py` file under `src/test/` (flat layout) with a
+module-level docstring describing the behavior under test. See
+[docs/standards/testing.md](docs/standards/testing.md) for the full policy.
+
+Run the suite:
+
+```sh
+uv run pytest
+
+# A single file
+uv run pytest src/test/test_box.py
+
+# With coverage
+uv run pytest --cov=src/pinet --cov-report=term-missing
 ```
-When you have edited the commit, press `Esc` and then type `:wq` to save. In `Visual Studio Code`, you should setup the editor with
-```bash
-git config core.editor "code --wait"
-```
-You may need to [setup the `code` command](https://code.visualstudio.com/docs/setup/mac).
-The `Commit style validation` action will fail if you do not adhere to the recommended style.
 
-Tip: When something fails, fix the issue and use:
-```bash
-git commit --amend
-git push --force
-```
+## Quality gates
 
-### Development workflow
-We follow a [Git feature branch](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) workflow with test-driven-development. In particular:
+All of these must pass before a PR (the pre-commit/pre-push hooks run them
+automatically; you can also run them by hand):
 
-- The basic workflow is as follows:
-  1. Open an issue for the feature to implement, and describe in detail the goal of the feature. Describe the tests that should pass for the feature to be considered implemented.
-  2. Open a branch from `dev` for the feature:
-    ```bash
-    git checkout dev
-    git checkout -b feature-<issue-number>
-    ```
-  3. Add the tests; see [Testing](#testing-a-feature).
-  4. Implement the feature and make sure the tests pass.
-  5. Open a PR to the `dev` branch. Note that the PR requires to `squash` the commit. See [Preparing for a PR](#preparing-for-a-pr).
-  6. Close the branch.
+```sh
+# Lint and format
+uv run pre-commit run --all-files
 
-- `main` and `dev` branches are protected from push, and require a PR.
-- We run github actions, [code-style](https://github.com/antonioterpin/pinet/blob/main/.github/workflows/code-style.yaml) and [tests](https://github.com/antonioterpin/pinet/blob/main/.github/workflows/tests.yaml) to check the test status on push on any branch. The rationale is that we want to know the state of each feature without polling the developer.
-- We open a PR to `main` only for milestones.
+# Type check (basedpyright; strict on both src/ and tests/)
+uv run pre-commit run --hook-stage push --all-files
 
-### Testing a feature
-To test a new feature, simply add a `test_<feature_to_test>` inside the folder `src/test`. For this, refer to the [`pytest` documentation](https://docs.pytest.org/en/stable/).
-
-To run the tests,
-```bash
-PYTHONPATH=src pytest
+# Tests
+uv run pytest
 ```
 
-### Preparing for a PR
-Before opening a PR to `dev`, you need to `squash` your commits into a single one. First, review your commit history to identify how many commits need to be squashed:
-```bash
-git log --oneline
-```
-For example, you may get
-```bash
-abc123 Feature added A
-def456 Fix for bug in feature A
-ghi789 Update documentation for feature A
-```
-Suppose you want to squash the three above into a single commit, `Implement feature <issue-number>`. You can rebase interactively to squash the commits:
-```bash
+If a hook keeps you from committing or pushing and you understand why it is
+safe to bypass it, add `--no-verify` — but CI will still enforce the gate.
+
+## Preparing for a PR
+
+Squash your branch into a single, well-formed Conventional-Commits commit
+before opening the PR so reviewers see one concise change:
+
+```sh
 git rebase -i HEAD~<number-of-commits>
 ```
-For example, if you want to squash the last 3 commits:
-```bash
-git rebase -i HEAD~3
-```
-An editor will open, showing a list of commits:
-```bash
-pick abc123 Feature added A
-pick def456 Fix for bug in feature A
-pick ghi789 Update documentation for feature A
-```
-- Keep the first commit as `pick`.
-- Change `pick` to `squash` (or `s`) for the subsequent commits:
-```bash
-pick abc123 Feature added A
-squash def456 Fix for bug in feature A
-squash ghi789 Update documentation for feature A
-```
-Save and close the editor.
-Git will prompt you to edit the combined commit message. You’ll see:
-```bash
-# This is a combination of 3 commits.
-# The first commit's message is:
-Feature added A
 
-# The following commit messages will also be included:
-Fix for bug in feature A
-Update documentation for feature A
-```
-Edit it into a single meaningful message, like:
-```bash
-Add feature A with bug fixes and documentation updates
-```
-Save and close the editor; Git will squash the commits. If there are conflicts during the rebase, resolve them and continue:
-```bash
-git rebase --continue
-```
-Verify the commit history:
-```bash
-git log --oneline
-```
-You should see one clean commit instead of multiple. If you’ve already pushed the branch to a remote repository, you need to force-push after squashing:
-```bash
-git push --force
-```
-Now that the feature branch has a clean history, create the PR from your feature branch to the main branch. The reviewers will see a single, concise commit summarizing your changes. See the [guidelines for commit messages](https://www.conventionalcommits.org/en/v1.0.0/#summary).
+Keep the first commit as `pick`, mark the rest `squash` (or `s`), then edit
+the combined message to follow the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+standard (see `.gitmessage`). Resolve any conflicts and
+`git rebase --continue`. If the branch was already pushed, force-push the
+squashed history (`git push --force-with-lease`). Then open the PR from your
+branch to `dev`.

--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ proj = Project(
 )
 
 x0 = jnp.array([[[10.0], [-10.0]]])             # point to project, shape (B, d, 1)
-yraw = ProjectionInstance(x=x0, nl=[nl_spec])
+y_raw = ProjectionInstance(x=x0, nl=[nl_spec])
 
-y, sK = proj.call(yraw=yraw, n_iter=500, sigma=1.0, omega=1.7)
+y, sK = proj.call(y_raw=y_raw, n_iter=500, sigma=1.0, omega=1.7)
 
 # Check the maximum violation across all constraints
 cv = proj.cv(y)
@@ -224,12 +224,12 @@ proj = Project(
 
 # Build a ProjectionInstance with the point to project and (optionally) runtime specs:
 x0 = jnp.zeros((B, d, 1))
-yraw = ProjectionInstance(x=x0)
+y_raw = ProjectionInstance(x=x0)
 # If var_b=True and you supply per-batch b at runtime, pass it via your dataclass, e.g.:
-# yraw = yraw.update(eq=yraw.eq.update(b=b))
+# y_raw = y_raw.update(eq=y_raw.eq.update(b=b))
 
 y, sK = proj.call(       # JIT-compiled projector
-    yraw=yraw,
+    y_raw=y_raw,
     n_iter=50,                    # Douglas-Rachford iterations
     n_iter_backward=100,          # Maximum number of iterations for the bicgstab algorithm
     sigma=1.0, omega=1.7,

--- a/README.md
+++ b/README.md
@@ -28,9 +28,16 @@ To install &Pi;net, run:
   ```bash
   pip install "pinet-hcnn[cuda12]"
   ```
+- GPU (NVIDIA, CUDA 13 — required for Blackwell / RTX 50-series)
+  ```bash
+  pip install "pinet-hcnn[cuda13]"
+  ```
+
+  Match the extra to the CUDA major version reported by `nvidia-smi`
+  ("CUDA Version"). `cuda13` requires `jax>=0.7.1` and Python `>=3.11`.
 
 > [!WARNING]
-> **CUDA dependencies**: If you have issues with CUDA drivers, please follow the official instructions for [cuda12 and cudnn](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_local) (Note: wheels only available on linux). If you have issues with conflicting CUDA libraries, check also [this issue](https://github.com/jax-ml/jax/issues/17497)... or use our Docker container 🤗.
+> **CUDA dependencies**: If you have issues with CUDA drivers, please follow the official instructions for [cuda and cudnn](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_local) (Note: wheels only available on linux). If you have issues with conflicting CUDA libraries, check also [this issue](https://github.com/jax-ml/jax/issues/17497)... or use our Docker container 🤗.
 
 We also provide a working [Docker](https://docs.docker.com/) image to reproduce the results of the paper and to build on top.
 ```bash

--- a/docs/agents/implementer.md
+++ b/docs/agents/implementer.md
@@ -2,7 +2,7 @@
 description: Task implementer for features and fixes
 ---
 
-You are an implementation agent for the PiNet repository.
+You are an implementation agent for the Pinet repository.
 
 ## Source of truth
 

--- a/docs/agents/reviewer.md
+++ b/docs/agents/reviewer.md
@@ -2,7 +2,7 @@
 description: Strict code reviewer for this repository
 ---
 
-You are a code reviewer for the PiNet repository.
+You are a code reviewer for the Pinet repository.
 
 ## Source of truth
 

--- a/docs/guides/agent-development.md
+++ b/docs/guides/agent-development.md
@@ -1,10 +1,10 @@
 # Agent-driven development guide
 
-This guide explains how to use the PiNet documentation and workflows with different agentic systems (Claude Code, GitHub Copilot, custom agents, etc.).
+This guide explains how to use the Pinet documentation and workflows with different agentic systems (Claude Code, GitHub Copilot, custom agents, etc.).
 
 ## Overview
 
-PiNet is optimized for agent-driven development. All rules, workflows, and procedures are centralized in the `docs/` folder, and compatibility layers in `.agent/`, `.github/`, and `.claude/` reference them.
+Pinet is optimized for agent-driven development. All rules, workflows, and procedures are centralized in the `docs/` folder, and compatibility layers in `.agent/`, `.github/`, and `.claude/` reference them.
 
 ## Infrastructure at a glance
 
@@ -113,7 +113,7 @@ The `.agent/` folder is already configured for Antigravity. Just use slash comma
 
 ### Integration pattern
 
-If you're building a custom agent for PiNet:
+If you're building a custom agent for Pinet:
 
 1. **Read `.claude/CLAUDE.md`** or **`.github/copilot-instructions.md`** to understand the project
 2. **Reference `docs/index.md`** as your documentation hub
@@ -125,7 +125,7 @@ If you're building a custom agent for PiNet:
 ```markdown
 # Your Custom Agent Configuration
 
-Follow PiNet project rules in docs/:
+Follow Pinet project rules in docs/:
 - Standards: docs/standards/
 - Workflows: docs/workflows/
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ One file per topic -- all code must satisfy these:
 | [naming.md](standards/naming.md) | Identifier conventions (`_mat` suffix, allowed uppercase, jaxtyping axes) |
 | [code-organization.md](standards/code-organization.md) | Module layout and ownership rules |
 | [typing-docstrings.md](standards/typing-docstrings.md) | Modern type hints (PEP 585/604), Google-style docstrings |
-| [testing.md](standards/testing.md) | TDD, Arrange/Act/Assert, coverage, hypothesis |
+| [testing.md](standards/testing.md) | pytest, docs-first tests, functionality-driven design, coverage |
 | [ml-numerical.md](standards/ml-numerical.md) | JAX, determinism, jit/vmap guidelines |
 | [api-design.md](standards/api-design.md) | Public API contracts, simplicity |
 | [change-scope.md](standards/change-scope.md) | What belongs in a single PR |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# PiNet documentation hub
+# Pinet documentation hub
 
-This is the single source of truth for all PiNet documentation related to agent-driven development. Start here.
+This is the single source of truth for all Pinet documentation related to agent-driven development. Start here.
 
 ---
 
@@ -8,7 +8,7 @@ This is the single source of truth for all PiNet documentation related to agent-
 
 | Document | What it covers |
 |---|---|
-| [agent-development.md](guides/agent-development.md) | Using PiNet with Claude Code, GitHub Copilot, Antigravity, and custom agents |
+| [agent-development.md](guides/agent-development.md) | Using Pinet with Claude Code, GitHub Copilot, Antigravity, and custom agents |
 
 The top-level [CONTRIBUTING.md](../CONTRIBUTING.md) covers human-facing development setup, branch workflow, PR preparation, and commit style.
 

--- a/docs/standards/code-clarity.md
+++ b/docs/standards/code-clarity.md
@@ -45,7 +45,7 @@
 
 - In markdown documentation **and in docstrings**, **only capitalize the first word** of headers, titles, and docstring section headings.
 - This rule applies to all Markdown files in the repository (including `docs/`, `README.md`, PR/issue templates) and to all Python docstrings (including the first-line summary and any in-docstring section headings).
-- Keep proper nouns, library names, and acronyms as needed (for example, `GitHub`, `API`, `JAX`, `NumPy`, `PiNet`, `CVXPY`, `QP`, `SOC`, `ADMM`).
+- Keep proper nouns, library names, and acronyms as needed (for example, `GitHub`, `API`, `JAX`, `NumPy`, `Pinet`, `CVXPY`, `QP`, `SOC`, `ADMM`).
 - Examples:
   - correct: `## Projection layer` (not `## Projection Layer`)
   - correct: `## Constraint types` (not `## Constraint Types`)

--- a/docs/standards/naming.md
+++ b/docs/standards/naming.md
@@ -10,20 +10,10 @@ Single source of truth for identifier naming across the library, tests, tools, a
 | Vector or offset | bare lowercase letter | `a`, `b`, `f`, `h`, `p`, `lb`, `ub`, `xhat` |
 | Scalar | bare lowercase letter | `alpha`, `sigma`, `omega`, `tol` |
 | Count or row dimension | `n_*` or `m_*` | `n_eq`, `n_ineq`, `n_a`, `n_c`, `n_a_soc_1`, `dim`, `dim_lifted` |
-| Flag (is per-instance) | `var_*` | `var_a_mat`, `var_b` |
+| Is per-instance | `var_*` | `var_a_mat`, `var_b` |
 | RNG key | `k*` prefix, matrix variant uses the full matrix name | `key`, `ka`, `kb`, `kf`, `kx`, `ka_mat`, `kc_mat` |
-| Boolean mask | `mask_*` | `mask_u`, `mask_t`, `box_mask` |
+| Boolean mask | `mask_*` | `mask_u`, `mask_t`, `mask_box` |
 | Private attribute | leading `_` | `_a_mat`, `_a`, `_f`, `_b`, `_nl_type`, `_dim`, `_rng_key` |
-
-## Per-spec attributes
-
-| Spec or class | Attributes | Role |
-|---------------|------------|------|
-| `EqualityConstraintsSpecification` | `a_mat`, `b`, `a_mat_pinv` | equality matrix, RHS vector, pinv of `a_mat` |
-| `AffineInequalityConstraint` | `c_mat`, `lb`, `ub` | inequality matrix, lower and upper bound vectors |
-| `BoxConstraintSpecification` | `lb`, `ub`, `mask` | box bounds plus the active-dim mask |
-| `SocConstraintSpecification` | `mask_u`, `mask_t`, `a`, `b` | cone-vector mask, scalar mask, offset vector, scalar offset |
-| `NonLinearSpecification` | `a_mat`, `a`, `f`, `b`, `nl_type` | NL matrix, offset vector, linear-RHS row, scalar bound, type tag |
 
 `EqualityConstraintsSpecification.a_mat` (matrix) and `NonLinearSpecification.a` (offset vector) are intentionally distinct attributes on different classes. The `_mat` suffix is what tells them apart at the call site.
 

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -6,9 +6,14 @@
 
 ## Test structure
 
-- Test directories **mirror `src/pinet/`** so you can find tests by module path.
-- **Keep test files small and focused.** One file per concern or layer.
-- Each test file has a **module-level docstring** explaining what behavior it verifies.
+- Tests live **flat in `src/test/`**, one file per area, named
+  `test_<area>.py` (e.g. `test_box.py`, `test_project.py`). A future
+  reorganization into a tree mirroring `src/pinet/` is tracked in
+  [issue #130](https://github.com/antonioterpin/pinet/issues/130).
+- **Prefer small, focused files**, one concern or layer per file. Some
+  legacy files are still large; split them when you touch them.
+- Each test file carries a **module-level docstring** explaining what
+  behavior it verifies.
 - Tests are **type-checked** under basedpyright, same as `src/`. Fixtures and helpers must carry accurate type hints.
 
 ## Test design
@@ -42,8 +47,8 @@ When adding tests to a new area:
 # All tests
 uv run pytest
 
-# A specific module
-uv run pytest src/test/constraints/
+# A specific file
+uv run pytest src/test/test_box.py
 
 # With coverage
 uv run pytest --cov=src/pinet --cov-report=term-missing

--- a/docs/workflows/orientation.md
+++ b/docs/workflows/orientation.md
@@ -5,7 +5,7 @@ description: First-time orientation before making changes
 Use when working on the project for the first time, or returning after a long absence. Goal: build a mental model of the system before touching code.
 
 1. **Read the project README.**
-   [`README.md`](../../README.md) at the repo root explains the scope and positioning of PiNet: a differentiable orthogonal projection layer for training hard-constrained neural networks.
+   [`README.md`](../../README.md) at the repo root explains the scope and positioning of Pinet: a differentiable orthogonal projection layer for training hard-constrained neural networks.
 
 2. **Read the contributing guide.**
    [`CONTRIBUTING.md`](../../CONTRIBUTING.md) covers development setup, branch workflow, PR preparation, and commit style.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,14 @@ dev = [
     "ruff>=0.14.14",
     "gitlint==0.19.1",
 ]
+# GPU extras. Pick the one matching the CUDA major version of the host driver
+# (`nvidia-smi` -> "CUDA Version"). cuda13 is required for CUDA 13 drivers and
+# Blackwell-class GPUs (e.g. RTX 50-series), and needs jax>=0.7.1 (python>=3.11).
 cuda12 = [
-    "jax[cuda12_pip]>=0.6.2",
+    "jax[cuda12]>=0.6.2",
+]
+cuda13 = [
+    "jax[cuda13]>=0.7.1; python_version >= '3.11'",
 ]
 
 [project.urls]

--- a/src/benchmarks/QP/load_qp.py
+++ b/src/benchmarks/QP/load_qp.py
@@ -89,7 +89,7 @@ def create_dataloaders(
     )
 
     def collate_fn(batch):
-        x_data, obj = zip(*batch, strict=False)
+        x_data, obj = zip(*batch, strict=True)
         return jnp.array(x_data), jnp.array(obj)
 
     train_loader = DataLoader(
@@ -231,7 +231,7 @@ def dc3_dataloader(
     dataset = DC3Dataset(filepath, use_convex)
 
     def collate_fn(batch):
-        x_data, obj = zip(*batch, strict=False)
+        x_data, obj = zip(*batch, strict=True)
         return jnp.array(x_data), jnp.array(obj)
 
     loader = DataLoader(

--- a/src/benchmarks/QP/parse_results.py
+++ b/src/benchmarks/QP/parse_results.py
@@ -280,7 +280,7 @@ def generate_time_data(id: str, config: str) -> None:
     for dict, name in zip(
         [single_inference_dict, inference_dict],
         ["single_inference", "inference"],
-        strict=False,
+        strict=True,
     ):
         all_stats = {}
         for method, (color, method_name) in methods_mapping.items():

--- a/src/benchmarks/QP/run_qp.py
+++ b/src/benchmarks/QP/run_qp.py
@@ -436,7 +436,7 @@ def main(
                 batch_sizes.append(x_batch.shape[0])
                 epoch_loss.append(loss)
             weighted_epoch_loss = sum(
-                el * bs for el, bs in zip(epoch_loss, batch_sizes, strict=False)
+                el * bs for el, bs in zip(epoch_loss, batch_sizes, strict=True)
             ) / sum(batch_sizes)
             trainig_losses.append(weighted_epoch_loss)
             pbar.set_description(f"Train Loss: {weighted_epoch_loss:.5f}")

--- a/src/benchmarks/model.py
+++ b/src/benchmarks/model.py
@@ -83,7 +83,7 @@ def setup_pinet(
     def project(x, b):
         inp = ProjectionInstance(x=x[..., None], eq=EqualityConstraintsSpecification(b=b))
         return projection_layer.call(
-            yraw=inp,
+            y_raw=inp,
             sigma=hyperparameters["sigma"],
             omega=hyperparameters["omega"],
             n_iter=hyperparameters["n_iter_train"],
@@ -93,7 +93,7 @@ def setup_pinet(
     def project_test(x, b):
         inp = ProjectionInstance(x=x[..., None], eq=EqualityConstraintsSpecification(b=b))
         return projection_layer.call(
-            yraw=inp,
+            y_raw=inp,
             sigma=hyperparameters["sigma"],
             omega=hyperparameters["omega"],
             n_iter=hyperparameters["n_iter_test"],

--- a/src/benchmarks/other_projections.py
+++ b/src/benchmarks/other_projections.py
@@ -66,7 +66,7 @@ def get_cvxpy_projection(
     c_mat: jax.Array,
     d: jax.Array,
     dim: int,
-) -> CvxpyLayer:
+) -> Callable[[jax.Array, jax.Array], tuple[jax.Array, ...]]:
     """Constructs and returns a CVXPY-based projection layer callable.
 
     The projection is formulated as a quadratic minimization problem that minimizes
@@ -82,7 +82,7 @@ def get_cvxpy_projection(
         dim: Dimension of the variable x.
 
     Returns:
-        Callable[[jax.Array, jax.Array], tuple[jax.Array]]:
+        Callable[[jax.Array, jax.Array], tuple[jax.Array, ...]]:
         A callable CVXPY layer that takes two parameters:
         an input vector (xproj) to be projected and a corresponding vector b for
         the equality constraints.

--- a/src/benchmarks/toy_MPC/load_toy_mpc.py
+++ b/src/benchmarks/toy_MPC/load_toy_mpc.py
@@ -93,7 +93,7 @@ def create_dataloaders(
     )
 
     def collate_fn(batch):
-        x0sets, obj = zip(*batch, strict=False)
+        x0sets, obj = zip(*batch, strict=True)
         return jnp.array(x0sets), jnp.array(obj)
 
     train_loader = DataLoader(

--- a/src/benchmarks/toy_MPC/run_toy_mpc.py
+++ b/src/benchmarks/toy_MPC/run_toy_mpc.py
@@ -290,7 +290,7 @@ def main(
                 batch_sizes.append(x_batch.shape[0])
                 epoch_loss.append(loss)
             weighted_epoch_loss = sum(
-                el * bs for el, bs in zip(epoch_loss, batch_sizes, strict=False)
+                el * bs for el, bs in zip(epoch_loss, batch_sizes, strict=True)
             ) / sum(batch_sizes)
             trainig_losses.append(weighted_epoch_loss)
             pbar.set_description(f"Train Loss: {weighted_epoch_loss:.5f}")

--- a/src/benchmarks/toy_SOC/main.py
+++ b/src/benchmarks/toy_SOC/main.py
@@ -17,17 +17,41 @@ from jax import numpy as jnp
 from jax import random as jrnd
 from jax.scipy.sparse.linalg import bicgstab
 
-CONSTRAINT_TOL = 1e-6
+# %% Hyperparameters
+# Every tunable knob for the SOC benchmark -- problem size, solver, and
+# training -- is collected here so a single block governs the run.
+HYPERPARAMETERS: dict[str, Any] = {
+    # Problem
+    "n": 250,  # primal dimension
+    "m": 250,  # number of equality / cone rows
+    "seed": 1,  # PRNG seed
+    "constraint_tol": 1e-6,  # feasibility tolerance used in validation
+    # Solver (Douglas-Rachford)
+    "n_iter_forward": 1000,  # forward solver iterations
+    "n_iter_backward": 200,  # backward (implicit-diff) solver iterations
+    "sigma": 0.1,  # step size
+    "omega": 1.8,  # relaxation parameter
+    # Training
+    "batch_size": 512,
+    "n_epochs": 1000,
+    "learning_rate": 1e-3,
+}
 
 # Use 64 bit precision for numerical stability
 jconf.update("jax_enable_x64", True)
 
-# %%
-# Problem dimensions
-n = 250
-m = 250
+n = HYPERPARAMETERS["n"]
+m = HYPERPARAMETERS["m"]
+CONSTRAINT_TOL = HYPERPARAMETERS["constraint_tol"]
+n_iter_forward = HYPERPARAMETERS["n_iter_forward"]
+n_iter_backward = HYPERPARAMETERS["n_iter_backward"]
+sigma = HYPERPARAMETERS["sigma"]
+omega = HYPERPARAMETERS["omega"]
+BATCH_SIZE = HYPERPARAMETERS["batch_size"]
+n_epochs = HYPERPARAMETERS["n_epochs"]
+learning_rate = HYPERPARAMETERS["learning_rate"]
 # Key
-key = jrnd.PRNGKey(1)
+key = jrnd.PRNGKey(HYPERPARAMETERS["seed"])
 
 use_custom_vjp = True
 custom_vjp: Any
@@ -269,19 +293,14 @@ s_cvxpy = jnp.asarray(s_sol).reshape(batch_size, m, 1)
 print_stats(x_cvxpy, s_cvxpy, b, c, xstar)
 
 # %% Use our solver
-n_iter_forward = 1e3
-n_iter_backward = 200
-sigma = 0.1
-omega = 1.8
-
-a_dyn_aug = jnp.concatenate((a_mat, jnp.eye(m)), axis=1)
+a_mat_aug = jnp.concatenate((a_mat, jnp.eye(m)), axis=1)
 # The augmented equality matrix must match the primal-plus-slack dimension.
-assert a_dyn_aug.shape == (
+assert a_mat_aug.shape == (
     m,
     m + n,
-), f"Augmented matrix a_mat should have shape ({m}, {m + n}), instead: {a_dyn_aug.shape}"
+), f"Augmented matrix a_mat should have shape ({m}, {m + n}), instead: {a_mat_aug.shape}"
 
-a_dyn_aug_inv = jnp.linalg.pinv(a_dyn_aug)
+a_mat_aug_inv = jnp.linalg.pinv(a_mat_aug)
 
 
 def project_pinv_vb(xs: jax.Array, b: jax.Array):
@@ -298,14 +317,14 @@ def project_pinv_vb(xs: jax.Array, b: jax.Array):
     Returns:
         jax.Array: Projected array satisfying the equality constraints.
     """
-    return xs - a_dyn_aug_inv @ (a_dyn_aug @ xs - b)
+    return xs - a_mat_aug_inv @ (a_mat_aug @ xs - b)
 
 
-def step_iteration(yraw: jax.Array, sk: jax.Array, b: jax.Array):
+def step_iteration(y_raw: jax.Array, sk: jax.Array, b: jax.Array):
     """Perform one iteration of the forward step.
 
     Args:
-        yraw:
+        y_raw:
             Raw input array of shape (B, m + n, 1) where the first n columns
             are the primal variables and the last m columns are residuals.
 
@@ -320,7 +339,7 @@ def step_iteration(yraw: jax.Array, sk: jax.Array, b: jax.Array):
     """
     zk = project_pinv_vb(sk, b)
     reflect = 2 * zk - sk
-    toproj = (reflect - 2 * sigma * yraw) / (1 + 2 * sigma)
+    toproj = (reflect - 2 * sigma * y_raw) / (1 + 2 * sigma)
     tk1 = toproj[:, :n]
     tk2 = project_soc(toproj[:, n:])
     tk = jnp.concatenate((tk1, tk2), axis=1)
@@ -343,14 +362,14 @@ def step_final(s: jax.Array, b: jax.Array) -> jax.Array:
 @custom_vjp
 def project(
     s0: jax.Array,
-    yraw: jax.Array,
+    y_raw: jax.Array,
     b: jax.Array,
 ):
     """Project the raw input onto the feasible set defined by the constraints.
 
     Args:
         s0: Initial governing sequence, shape (B, m + n, 1).
-        yraw: Raw input array, shape (B, m + n, 1).
+        y_raw: Raw input array, shape (B, m + n, 1).
         b: Right-hand side of the equality constraints, shape (B, m, 1).
 
     Returns:
@@ -361,7 +380,7 @@ def project(
     sk = s0
     sk, _ = lax.scan(
         lambda sk, _: (
-            step_iteration(yraw.reshape((yraw.shape[0], yraw.shape[1], 1)), sk, b),
+            step_iteration(y_raw.reshape((y_raw.shape[0], y_raw.shape[1], 1)), sk, b),
             None,
         ),
         sk,
@@ -370,18 +389,18 @@ def project(
     )
 
     # NOTE: There is no auxiliary variable in this case
-    zk1 = step_final(sk, b).reshape(yraw.shape)
+    zk1 = step_final(sk, b).reshape(y_raw.shape)
 
     # return values and residuals
     return zk1, sk
 
 
-def _project_fwd(s0: jax.Array, yraw: jax.Array, b: jax.Array):
+def _project_fwd(s0: jax.Array, y_raw: jax.Array, b: jax.Array):
     """Forward pass of the projection function.
 
     Args:
         s0: Initial governing sequence, shape (B, m + n, 1).
-        yraw: Raw input array, shape (B, m + n, 1).
+        y_raw: Raw input array, shape (B, m + n, 1).
         b: Right-hand side of the equality constraints, shape (B, m, 1).
 
     Returns:
@@ -389,10 +408,10 @@ def _project_fwd(s0: jax.Array, yraw: jax.Array, b: jax.Array):
             - zk1 (jax.Array): Projected value, shape (B, m + n, 1).
             - sk (jax.Array): Final governing sequence, shape (B, m + n, 1).
         - tuple:
-            - (sk, yraw, b): Residuals for the backward pass.
+            - (sk, y_raw, b): Residuals for the backward pass.
     """
-    zk1, sk = project(s0, yraw, b)
-    return (zk1, sk), (sk, yraw.reshape((yraw.shape[0], yraw.shape[1], 1)), b)
+    zk1, sk = project(s0, y_raw, b)
+    return (zk1, sk), (sk, y_raw.reshape((y_raw.shape[0], y_raw.shape[1], 1)), b)
 
 
 def _project_bwd(residuals: tuple[Any, ...], cotangent: tuple[Any, ...]):
@@ -401,7 +420,7 @@ def _project_bwd(residuals: tuple[Any, ...], cotangent: tuple[Any, ...]):
     Args:
         residuals: Residuals from the forward pass, containing:
             - sk (jax.Array): Governing sequence, shape (B, m + n, 1).
-            - yraw (jax.Array): Raw input array, shape (B, m + n, 1).
+            - y_raw (jax.Array): Raw input array, shape (B, m + n, 1).
             - b (jax.Array):
                 Right-hand side of the equality constraints, shape (B, m, 1).
 
@@ -415,30 +434,30 @@ def _project_bwd(residuals: tuple[Any, ...], cotangent: tuple[Any, ...]):
         tuple:
             - None: Placeholder for the vjp wrt to sk (the DRA governing sequence).
             - thevjp (jax.Array):
-                The vjp wrt to yraw, shape (B, m + n, 1).
+                The vjp wrt to y_raw, shape (B, m + n, 1).
             - None: Placeholder for the vjp wrt to b
                 (the right-hand side of the equality constraints).
     """
-    sk, yraw, b = residuals
+    sk, y_raw, b = residuals
     cotangent_zk1, _ = cotangent
 
     # Compute the vjp of the iteration step wrt to the DRA governing sequence
-    _, iteration_vjp = vjp(lambda xx: step_iteration(yraw, xx, b), sk)
+    _, iteration_vjp = vjp(lambda xx: step_iteration(y_raw, xx, b), sk)
     # Compute the vjp of the iteration step wrt to the value to be projected
-    _, iteration_vjp2 = vjp(lambda xx: step_iteration(xx, sk, b), yraw)
+    _, iteration_vjp2 = vjp(lambda xx: step_iteration(xx, sk, b), y_raw)
     # Compute the vjp of the final step wrt to DRA governing sequence
     _, equality_vjp = vjp(lambda xx: step_final(xx, b), sk)
 
     cotangent_eq_6 = equality_vjp(cotangent_zk1)[0]
 
-    def aop(xx):
+    def a_mat_op(xx):
         return xx - iteration_vjp(xx)[0]
 
-    cotangent_eq_7 = bicgstab(aop, cotangent_eq_6, maxiter=n_iter_backward)[0]
+    cotangent_eq_7 = bicgstab(a_mat_op, cotangent_eq_6, maxiter=n_iter_backward)[0]
 
     thevjp = iteration_vjp2(cotangent_eq_7)[0]
 
-    # We only care about the vjp wrt to yraw
+    # We only care about the vjp wrt to y_raw
     # So, we return None for the vjp wrt to sk (the DRA governing sequence)
     # and None for the vjp wrt to b (the right-hand side of the equality constraints)
     return (None, thevjp, None)
@@ -462,10 +481,10 @@ def test_projection(b: jax.Array, c: jax.Array, xstar: jax.Array, sstar: jax.Arr
         sstar: Optimal dual solution, shape (B, m, 1).
     """
     n_samples = b.shape[0]
-    yraw = jrnd.uniform(key, (n_samples, n + m, 1))
+    y_raw = jrnd.uniform(key, (n_samples, n + m, 1))
 
-    x = yraw[:, :n]
-    s = yraw[:, n:]
+    x = y_raw[:, :n]
+    s = y_raw[:, n:]
     cv_eq_raw = constraint_violation_eq(x, s, b)
     cv_soc_raw = constraint_violation_soc(s)
     if jnp.all(cv_eq_raw < CONSTRAINT_TOL) and jnp.all(cv_soc_raw < CONSTRAINT_TOL):
@@ -477,7 +496,7 @@ def test_projection(b: jax.Array, c: jax.Array, xstar: jax.Array, sstar: jax.Arr
         print(f"Optimal sample: {cv_eq_opt.max()=}, {cv_soc_opt.max()=}")
 
     # Project the point
-    y, _ = project(jnp.zeros_like(yraw), yraw, b)
+    y, _ = project(jnp.zeros_like(y_raw), y_raw, b)
     x = y[:, :n]
     s = y[:, n:]
 
@@ -534,9 +553,6 @@ class HardConstrainedMLP(nn.Module):
 
 
 # %% Train the MLP
-BATCH_SIZE = 512
-n_epochs = 1000
-learning_rate = 1e-3
 key_train, key_init = jrnd.split(key)
 
 

--- a/src/benchmarks/toy_SOC/main.py
+++ b/src/benchmarks/toy_SOC/main.py
@@ -35,6 +35,8 @@ HYPERPARAMETERS: dict[str, Any] = {
     "batch_size": 512,
     "n_epochs": 1000,
     "learning_rate": 1e-3,
+    # Validation
+    "validation_batch_size": 1024,  # reference (CVXPY) problem instances
 }
 
 # Use 64 bit precision for numerical stability
@@ -50,6 +52,7 @@ omega = HYPERPARAMETERS["omega"]
 BATCH_SIZE = HYPERPARAMETERS["batch_size"]
 n_epochs = HYPERPARAMETERS["n_epochs"]
 learning_rate = HYPERPARAMETERS["learning_rate"]
+VALIDATION_BATCH_SIZE = HYPERPARAMETERS["validation_batch_size"]
 # Key
 key = jrnd.PRNGKey(HYPERPARAMETERS["seed"])
 
@@ -257,9 +260,8 @@ def print_stats(x: jax.Array, s: jax.Array, b: jax.Array, c: jax.Array, xstar: j
 
 
 # %% Validate the problem
-batch_size = 1024
 # Symbolic problem
-b, c, xstar, sstar = generate_problem(key, batch_size)
+b, c, xstar, sstar = generate_problem(key, VALIDATION_BATCH_SIZE)
 
 # %% CVXPY
 A_np = np.asarray(a_mat)
@@ -273,7 +275,7 @@ constraints = [A_np @ x_var + s_var == b_par, cp.SOC(s_var[-1], s_var[:-1])]
 problem = cp.Problem(cp.Minimize(c_par @ x_var), cast(list[CvxpyConstraint], constraints))
 x_sol = []
 s_sol = []
-for i in range(batch_size):
+for i in range(VALIDATION_BATCH_SIZE):
     b_par.value = np.asarray(b[i]).ravel()  # shape (m,)
     c_par.value = np.asarray(c[i]).ravel()  # shape (n,)
 
@@ -286,8 +288,8 @@ for i in range(batch_size):
     x_sol.append(x_var.value.reshape(n, 1))
     s_sol.append(s_var.value.reshape(m, 1))
 
-x_cvxpy = jnp.asarray(x_sol).reshape(batch_size, n, 1)
-s_cvxpy = jnp.asarray(s_sol).reshape(batch_size, m, 1)
+x_cvxpy = jnp.asarray(x_sol).reshape(VALIDATION_BATCH_SIZE, n, 1)
+s_cvxpy = jnp.asarray(s_sol).reshape(VALIDATION_BATCH_SIZE, m, 1)
 
 # Print the statistics of the solution
 print_stats(x_cvxpy, s_cvxpy, b, c, xstar)

--- a/src/pinet/_typing.py
+++ b/src/pinet/_typing.py
@@ -16,6 +16,8 @@ Each alias below names a common shape so call sites stay short and docstrings
 no longer need to carry shape/dtype prose.
 """
 
+from typing import Any
+
 import numpy as np
 from jaxtyping import Array, Bool, Float, Real
 
@@ -24,7 +26,7 @@ from jaxtyping import Array, Bool, Float, Real
 # promotes them at the first arithmetic op. ``ArrayLike`` widens
 # jaxtyping's first-slot type so beartype accepts either backend without
 # forcing callers to ``jnp.asarray`` everywhere.
-ArrayLike = Array | np.ndarray
+ArrayLike = Array | np.ndarray[Any, np.dtype[Any]]
 
 # The ``#B`` prefix marks the batch axis as broadcast-compatible, so a
 # function that accepts both a per-instance tensor (``B=10``) and a

--- a/src/pinet/constraints/affine_equality.py
+++ b/src/pinet/constraints/affine_equality.py
@@ -108,11 +108,11 @@ class EqualityConstraint(Constraint):
         a_mat_pinv = inp.eq.a_mat_pinv if inp.eq and self.var_a_mat else self.a_mat_pinv
         return b, a_mat, a_mat_pinv
 
-    def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def project(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Project onto equality constraints.
 
         Args:
-            yraw: ProjectionInstance to project.
+            y_raw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:
@@ -123,19 +123,19 @@ class EqualityConstraint(Constraint):
         """
         if self.method is None:
             raise NotImplementedError("No projection method set.")
-        return self.project_pinv(yraw)
+        return self.project_pinv(y_raw)
 
-    def project_pinv(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def project_pinv(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Project onto equality constraints using pseudo-inverse.
 
         Args:
-            yraw: ProjectionInstance to project.
+            y_raw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:
             The projected point for each point in the batch.
         """
-        b, a_mat, a_mat_pinv = self.get_params(yraw)
+        b, a_mat, a_mat_pinv = self.get_params(y_raw)
         # a_mat must be available to apply the projection.
         assert a_mat is not None, (
             "a_mat must be provided in EqualityConstraintsSpecification "
@@ -144,7 +144,7 @@ class EqualityConstraint(Constraint):
         if a_mat_pinv is None:
             a_mat_pinv = jnp.linalg.pinv(a_mat)
 
-        return yraw.update(x=yraw.x - a_mat_pinv @ (a_mat @ yraw.x - b))
+        return y_raw.update(x=y_raw.x - a_mat_pinv @ (a_mat @ y_raw.x - b))
 
     @property
     def dim(self) -> int:
@@ -156,17 +156,17 @@ class EqualityConstraint(Constraint):
         """Return the number of constraints."""
         return self.a_mat.shape[1]
 
-    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
+    def cv(self, y_raw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
-            yraw: ProjectionInstance to evaluate.
+            y_raw: ProjectionInstance to evaluate.
 
         Returns:
             The constraint violation for each point in the batch.
         """
-        b, a_mat, _ = self.get_params(yraw)
+        b, a_mat, _ = self.get_params(y_raw)
         # a_mat must be available to compute the violation.
         assert a_mat is not None
 
-        return jnp.linalg.norm(a_mat @ yraw.x - b, ord=jnp.inf, axis=1, keepdims=True)
+        return jnp.linalg.norm(a_mat @ y_raw.x - b, ord=jnp.inf, axis=1, keepdims=True)

--- a/src/pinet/constraints/affine_inequality.py
+++ b/src/pinet/constraints/affine_inequality.py
@@ -56,11 +56,11 @@ class AffineInequalityConstraint(Constraint):
         self.lb = lb
         self.ub = ub
 
-    def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def project(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Project x onto the affine inequality constraint set.
 
         Args:
-            yraw: ProjectionInstance to project.
+            y_raw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:
@@ -83,16 +83,16 @@ class AffineInequalityConstraint(Constraint):
         """Return the number of constraints."""
         return self.c_mat.shape[1]
 
-    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
+    def cv(self, y_raw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
-            yraw: ProjectionInstance to evaluate.
+            y_raw: ProjectionInstance to evaluate.
 
         Returns:
             The constraint violation for each point in the batch.
         """
-        c_mat_x = self.c_mat @ yraw.x
+        c_mat_x = self.c_mat @ y_raw.x
         cv_ub = jnp.maximum(c_mat_x - self.ub, 0)
         cv_lb = jnp.maximum(self.lb - c_mat_x, 0)
         return jnp.max(jnp.maximum(cv_ub, cv_lb), axis=1, keepdims=True)

--- a/src/pinet/constraints/base.py
+++ b/src/pinet/constraints/base.py
@@ -15,11 +15,11 @@ class Constraint(eqx.Module):
     ``ABCMeta`` as its metaclass.
     """
 
-    def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def project(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Project the input to the feasible region.
 
         Args:
-            yraw: ProjectionInstance to project.
+            y_raw: ProjectionInstance to project.
 
         Returns:
             The projected input.
@@ -31,11 +31,11 @@ class Constraint(eqx.Module):
             f"{type(self).__name__}.project must be implemented by a subclass."
         )
 
-    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
+    def cv(self, y_raw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
-            yraw: ProjectionInstance to evaluate.
+            y_raw: ProjectionInstance to evaluate.
 
         Returns:
             The constraint violation for each point in the batch.

--- a/src/pinet/constraints/box.py
+++ b/src/pinet/constraints/box.py
@@ -22,7 +22,7 @@ class BoxConstraint(Constraint):
         lb: Lower bound for each constrained coordinate.
         ub: Upper bound for each constrained coordinate.
         mask: Boolean mask selecting which dimensions are constrained.
-        scale: Scaling vector applied to variable bounds passed via ``yraw.box``.
+        scale: Scaling vector applied to variable bounds passed via ``y_raw.box``.
     """
 
     lb: BatchedRHS | None
@@ -43,7 +43,7 @@ class BoxConstraint(Constraint):
             box_spec: Specification of the box constraint.
                 For variable bounds, provide an example of the bounds.
             scale: Optional scaling vector applied to variable bounds passed via
-                ``yraw.box``. Defaults to all ones.
+                ``y_raw.box``. Defaults to all ones.
         """
         lb = box_spec.lb
         ub = box_spec.ub
@@ -72,7 +72,7 @@ class BoxConstraint(Constraint):
             else jnp.asarray(np.ones(shape=(dim,), dtype=jnp.bool_))
         )
         # Default scale is applied to per-instance bounds supplied via
-        # ``yraw.box.lb/ub``, which have shape ``(batch, n_constraints, 1)``.
+        # ``y_raw.box.lb/ub``, which have shape ``(batch, n_constraints, 1)``.
         # Using ``dim`` here would broadcast-error whenever ``mask`` is set
         # (``dim != n_constraints``).
         self.scale = scale if scale is not None else jnp.ones((1, n_constraints, 1))
@@ -80,27 +80,27 @@ class BoxConstraint(Constraint):
         self._n_constraints = n_constraints
 
     def get_params(
-        self, yraw: ProjectionInstance
+        self, y_raw: ProjectionInstance
     ) -> tuple[BatchedRHS, BatchedRHS, Mask1D]:
         """Get the parameters of the box constraint.
 
         Args:
-            yraw: ProjectionInstance to get the parameters from.
+            y_raw: ProjectionInstance to get the parameters from.
 
         Returns:
             A tuple ``(lb, ub, mask)`` with the lower/upper bounds and the mask.
         """
         lb = (
-            (yraw.box.lb * self.scale)
-            if yraw.box and yraw.box.lb is not None
+            (y_raw.box.lb * self.scale)
+            if y_raw.box and y_raw.box.lb is not None
             else self.lb
         )
         ub = (
-            (yraw.box.ub * self.scale)
-            if yraw.box and yraw.box.ub is not None
+            (y_raw.box.ub * self.scale)
+            if y_raw.box and y_raw.box.ub is not None
             else self.ub
         )
-        mask = yraw.box.mask if yraw.box and yraw.box.mask is not None else self.mask
+        mask = y_raw.box.mask if y_raw.box and y_raw.box.mask is not None else self.mask
         if lb is None:
             # An absent lower bound is treated as an unbounded interval below.
             assert ub is not None
@@ -112,36 +112,36 @@ class BoxConstraint(Constraint):
 
         return lb, ub, mask
 
-    def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def project(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Project the input to the feasible region.
 
         Args:
-            yraw: ProjectionInstance to project.
+            y_raw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:
             The projected point for each point in the batch.
         """
-        lb, ub, mask = self.get_params(yraw)
-        # ``yraw.x`` is annotated ``ArrayLike`` (jax.Array | np.ndarray) at the
+        lb, ub, mask = self.get_params(y_raw)
+        # ``y_raw.x`` is annotated ``ArrayLike`` (jax.Array | np.ndarray) at the
         # public API boundary; ``.at`` is a JAX-only construct, so coerce
         # before slicing.
-        x = jnp.asarray(yraw.x)
-        return yraw.update(x=x.at[:, mask, :].set(jnp.clip(x[:, mask, :], lb, ub)))
+        x = jnp.asarray(y_raw.x)
+        return y_raw.update(x=x.at[:, mask, :].set(jnp.clip(x[:, mask, :], lb, ub)))
 
-    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
+    def cv(self, y_raw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
-            yraw: ProjectionInstance to evaluate.
+            y_raw: ProjectionInstance to evaluate.
 
         Returns:
             The constraint violation for each point in the batch.
         """
-        lb, ub, mask = self.get_params(yraw)
+        lb, ub, mask = self.get_params(y_raw)
         cvs = jnp.maximum(
-            jnp.max(yraw.x[:, mask, :] - ub, axis=1, keepdims=True),
-            jnp.max(lb - yraw.x[:, mask, :], axis=1, keepdims=True),
+            jnp.max(y_raw.x[:, mask, :] - ub, axis=1, keepdims=True),
+            jnp.max(lb - y_raw.x[:, mask, :], axis=1, keepdims=True),
         )
         return jnp.maximum(cvs, 0)
 

--- a/src/pinet/constraints/cartesian_constraint.py
+++ b/src/pinet/constraints/cartesian_constraint.py
@@ -139,42 +139,42 @@ class CartesianConstraint(Constraint):
         """Return all constituent constraints in order."""
         return [c for c in (self.box_constraint, *self.nl_constraints) if c is not None]
 
-    def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def project(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Project the input to the feasible region.
 
         Projects onto each constraint independently. Since masks don't overlap,
         each constraint operates on a disjoint subset of variables.
 
         Args:
-            yraw: ProjectionInstance to project.
+            y_raw: ProjectionInstance to project.
 
         Returns:
             The projected input.
         """
-        if self.nl_constraints and not isinstance(yraw.nl, (list, tuple)):
+        if self.nl_constraints and not isinstance(y_raw.nl, (list, tuple)):
             raise TypeError(
-                f"yraw.nl must be a list or tuple, got {type(yraw.nl).__name__}."
+                f"y_raw.nl must be a list or tuple, got {type(y_raw.nl).__name__}."
             )
 
         if self.box_constraint is not None:
-            yraw = self.box_constraint.project(yraw)
+            y_raw = self.box_constraint.project(y_raw)
 
         if self.nl_constraints:
             # Narrowed by the isinstance check above.
-            assert yraw.nl is not None
-            for nl_constraint, nl_spec in zip(self.nl_constraints, yraw.nl, strict=True):
-                yraw = yraw.update(soc=nl_spec.to_primitive_spec())
-                yraw = nl_constraint.project(yraw)
+            assert y_raw.nl is not None
+            for nl_constraint, nl_spec in zip(self.nl_constraints, y_raw.nl, strict=True):
+                y_raw = y_raw.update(soc=nl_spec.to_primitive_spec())
+                y_raw = nl_constraint.project(y_raw)
 
-        return yraw
+        return y_raw
 
-    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
+    def cv(self, y_raw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Returns the maximum constraint violation across all constraints.
 
         Args:
-            yraw: ProjectionInstance to evaluate.
+            y_raw: ProjectionInstance to evaluate.
 
         Returns:
             The constraint violation for each point in the batch.
@@ -182,16 +182,16 @@ class CartesianConstraint(Constraint):
         cvs = []
 
         if self.box_constraint is not None:
-            cvs.append(self.box_constraint.cv(yraw).reshape(-1))
+            cvs.append(self.box_constraint.cv(y_raw).reshape(-1))
 
         if self.nl_constraints:
             # cv requires per-instance SOC specs to be supplied on the input.
-            assert yraw.nl is not None, (
-                "yraw.nl must be provided when non-linear constraints are present."
+            assert y_raw.nl is not None, (
+                "y_raw.nl must be provided when non-linear constraints are present."
             )
-            for constraint, nl_spec in zip(self.nl_constraints, yraw.nl, strict=True):
-                yraw = yraw.update(soc=nl_spec.to_primitive_spec())
-                cvs.append(constraint.cv(yraw).reshape(-1))
+            for constraint, nl_spec in zip(self.nl_constraints, y_raw.nl, strict=True):
+                y_raw = y_raw.update(soc=nl_spec.to_primitive_spec())
+                cvs.append(constraint.cv(y_raw).reshape(-1))
 
         # Return the maximum violation
         if len(cvs) == 1:

--- a/src/pinet/constraints/constraint_parser.py
+++ b/src/pinet/constraints/constraint_parser.py
@@ -186,7 +186,7 @@ class ConstraintParser:
             ),
             (mb_ac // ineq_constraint.c_mat.shape[0], 1, 1),
         )
-        a_dyn_lifted = jnp.concatenate([first_row_batched, second_row_batched], axis=1)
+        a_mat_lifted = jnp.concatenate([first_row_batched, second_row_batched], axis=1)
         b_lifted = jnp.concatenate(
             [
                 eq_constraint.b,
@@ -195,7 +195,7 @@ class ConstraintParser:
             axis=1,
         )
         eq_lifted = EqualityConstraint(
-            a_mat=a_dyn_lifted,
+            a_mat=a_mat_lifted,
             b=b_lifted,
             method=method,
             var_b=eq_constraint.var_b,
@@ -204,14 +204,14 @@ class ConstraintParser:
 
         if self.box_constraint is None:
             # We only project the lifted part.
-            box_mask = jnp.concatenate(
+            mask_box = jnp.concatenate(
                 [jnp.zeros(self.dim, dtype=bool), jnp.ones(self.n_ineq, dtype=bool)]
             )
             box_lifted = BoxConstraint(
                 BoxConstraintSpecification(
                     lb=ineq_constraint.lb,
                     ub=ineq_constraint.ub,
-                    mask=box_mask,
+                    mask=mask_box,
                 )
             )
         else:
@@ -222,7 +222,7 @@ class ConstraintParser:
             assert self.box_constraint.lb is not None
             # The original upper bounds are needed to concatenate lifted bounds.
             assert self.box_constraint.ub is not None
-            box_mask = jnp.concatenate(
+            mask_box = jnp.concatenate(
                 [
                     self.box_constraint.mask,
                     jnp.ones(self.n_ineq, dtype=bool),
@@ -268,7 +268,7 @@ class ConstraintParser:
                 BoxConstraintSpecification(
                     lb=lifted_lb,
                     ub=lifted_ub,
-                    mask=box_mask,
+                    mask=mask_box,
                 )
             )
 
@@ -382,7 +382,7 @@ class ConstraintParser:
         )
         # Define lifted equality constraints. ``var_a_mat`` propagates from the
         # input: when the user supplies a per-instance ``a_mat`` via
-        # ``yraw.eq.a_mat``, ``solver.admm.initialize`` re-runs
+        # ``y_raw.eq.a_mat``, ``solver.admm.initialize`` re-runs
         # ``parse_non_linear`` with the new value and produces a fresh lifted
         # ``a_mat`` / ``a_mat_pinv`` whose top block reflects that input.
         eq_lifted = EqualityConstraint(
@@ -403,30 +403,30 @@ class ConstraintParser:
                 # Explicit box with a mask: use its masks and bounds directly.
                 assert self.box_constraint.lb is not None
                 assert self.box_constraint.ub is not None
-                box_mask_init = self.box_constraint.mask
+                mask_box_init = self.box_constraint.mask
                 box_lb_init = self.box_constraint.lb
                 box_ub_init = self.box_constraint.ub
             else:
-                box_mask_init = jnp.zeros(self.dim, dtype=jnp.bool_)
+                mask_box_init = jnp.zeros(self.dim, dtype=jnp.bool_)
                 box_lb_init = jnp.full((1, 0, 1), -jnp.inf)
                 box_ub_init = jnp.full((1, 0, 1), jnp.inf)
             if self.ineq_constraint is not None:
-                box_mask_ineq = jnp.ones(
+                mask_box_ineq = jnp.ones(
                     self.ineq_constraint.n_constraints, dtype=jnp.bool_
                 )
                 box_lb_ineq = self.ineq_constraint.lb
                 box_ub_ineq = self.ineq_constraint.ub
                 n_curr += self.ineq_constraint.n_constraints
             else:
-                box_mask_ineq = jnp.zeros(shape=(0,), dtype=jnp.bool_)
+                mask_box_ineq = jnp.zeros(shape=(0,), dtype=jnp.bool_)
                 box_lb_ineq = jnp.full((1, 0, 1), -jnp.inf)
                 box_ub_ineq = jnp.full((1, 0, 1), jnp.inf)
-            box_mask_other = jnp.array(
-                [False] * (n_tot - box_mask_init.size - box_mask_ineq.size),
+            mask_box_other = jnp.array(
+                [False] * (n_tot - mask_box_init.size - mask_box_ineq.size),
                 dtype=jnp.bool_,
             )
-            box_mask_lifted = jnp.concatenate(
-                [box_mask_init, box_mask_ineq, box_mask_other], axis=0
+            mask_box_lifted = jnp.concatenate(
+                [mask_box_init, mask_box_ineq, mask_box_other], axis=0
             )
             box_lb_lifted = jnp.concatenate([box_lb_init, box_lb_ineq], axis=1)
             box_ub_lifted = jnp.concatenate([box_ub_init, box_ub_ineq], axis=1)
@@ -434,7 +434,7 @@ class ConstraintParser:
                 BoxConstraintSpecification(
                     lb=box_lb_lifted,
                     ub=box_ub_lifted,
-                    mask=box_mask_lifted,
+                    mask=mask_box_lifted,
                 )
             )
         # Non-linear constraints. SOCType and L2NormType both lower to the

--- a/src/pinet/constraints/non_linear.py
+++ b/src/pinet/constraints/non_linear.py
@@ -85,11 +85,11 @@ class NonLinearConstraint(Constraint):
         """Return the type of non-linear constraint."""
         return self._nl_type
 
-    def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def project(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Project the input to the feasible region.
 
         Args:
-            yraw: ProjectionInstance to project.
+            y_raw: ProjectionInstance to project.
 
         Returns:
             The projected input.
@@ -102,11 +102,11 @@ class NonLinearConstraint(Constraint):
             "NonLinearConstraint is a parameter carrier; use a concrete subclass."
         )
 
-    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
+    def cv(self, y_raw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         Args:
-            yraw: ProjectionInstance to evaluate.
+            y_raw: ProjectionInstance to evaluate.
 
         Returns:
             The constraint violation for each point in the batch.

--- a/src/pinet/constraints/soc_constraint.py
+++ b/src/pinet/constraints/soc_constraint.py
@@ -89,17 +89,17 @@ class SocConstraint(Constraint):
         t = inp.x[:, mask_t, :] + b
         return mask_u, u, mask_t, t, a, b
 
-    def project(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def project(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Project onto SOC constraints.
 
         Args:
-            yraw: ProjectionInstance to project.
+            y_raw: ProjectionInstance to project.
                 The .x attribute is the point to project.
 
         Returns:
             The projected point for each point in the batch.
         """
-        mask_u, u, mask_t, t, a, b = self.unpack_instance(yraw)
+        mask_u, u, mask_t, t, a, b = self.unpack_instance(y_raw)
         norm_u = jnp.linalg.norm(u, axis=1, keepdims=True)
         z: jax.Array = jnp.concatenate([u, t], axis=1)
 
@@ -116,27 +116,27 @@ class SocConstraint(Constraint):
         final_proj: jax.Array = jnp.where(when1, proj1, inner)
 
         # Coerce to jax.Array before using ``.at`` (jax-only).
-        x = jnp.asarray(yraw.x)
-        return yraw.update(
+        x = jnp.asarray(y_raw.x)
+        return y_raw.update(
             x=x.at[:, mask_u, :]
             .set(final_proj[:, :-1, :] - a)
             .at[:, mask_t, :]
             .set(final_proj[:, -1:, :] - b)
         )
 
-    def cv(self, yraw: ProjectionInstance) -> BatchedScalar:
+    def cv(self, y_raw: ProjectionInstance) -> BatchedScalar:
         """Compute the constraint violation.
 
         The SOC constraint is: ||u + a||_2 <= t + b. The violation is
         ``max(0, ||u + a||_2 - (t + b))``.
 
         Args:
-            yraw: ProjectionInstance to evaluate.
+            y_raw: ProjectionInstance to evaluate.
 
         Returns:
             The constraint violation for each point in the batch.
         """
-        _mask_u, u, _mask_t, t, _a, _b = self.unpack_instance(yraw)
+        _mask_u, u, _mask_t, t, _a, _b = self.unpack_instance(y_raw)
         norm_u = jnp.linalg.norm(u, axis=1, keepdims=True)
 
         # Constraint violation: ||u||_2 - t (where u and t already include a and b)

--- a/src/pinet/project.py
+++ b/src/pinet/project.py
@@ -92,7 +92,7 @@ class Project:
             )
             if c is not None
         ]
-        # The projection layer is meaningful only if at least one constraint is active.
+        # The projection layer is meaningful only if at least one constraint is present.
         assert len(constraints) > 0, "At least one constraint must be provided."
         self.dim = constraints[0].dim
 
@@ -104,7 +104,7 @@ class Project:
         self.is_single_simple_constraint = is_single_simple_constraint
 
         self.dim_lifted = self.dim
-        self.step_iteration = lambda s_prev, yraw, sigma, omega: s_prev
+        self.step_iteration = lambda s_prev, y_raw, sigma, omega: s_prev
         self.step_final = self._project_single
         self.single_constraint = constraints[0]
         self.d_r = jnp.ones((1, self.single_constraint.n_constraints, 1))
@@ -220,13 +220,15 @@ class Project:
                 )
 
         if is_single_simple_constraint:
-            # For a single simple constraint the projection is a closed-form
-            # one-step operation: proj(x) = x - A^+ (A x - b),
-            # where A is ``a_mat``, A^+ is ``a_mat_pinv``, and b is ``b``.
-            # The ADMM initializer zeros out yraw.x, causing _project_single
+            # A single simple constraint -- exactly one of an equality or a box
+            # constraint -- has a closed-form projection that _project_single
+            # applies directly: proj(x) = x - A^+ (A x - b) for the equality
+            # case (A is ``a_mat``, A^+ is ``a_mat_pinv``, b is ``b``), or a
+            # clamp for the box case.
+            # The ADMM initializer zeros out y_raw.x, causing _project_single
             # to project the origin rather than the actual input point.
-            # Override initialize so yraw.x is preserved end-to-end.
-            self.initialize = lambda yraw: yraw
+            # Override initialize so y_raw.x is preserved end-to-end.
+            self.initialize = lambda y_raw: y_raw
 
         project_fn = (
             _project_general
@@ -256,17 +258,17 @@ class Project:
         # jit correctly the call method
         self.call = self._project
 
-    def initialize(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def initialize(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Returns a zero initial value for the governing sequence.
 
         Args:
-            yraw: Point to be projected data.
+            y_raw: Point to be projected data.
 
         Returns:
             ProjectionInstance: Initial value for the governing sequence.
         """
         return initialize(
-            yraw=yraw,
+            y_raw=y_raw,
             ineq_constraint=self.ineq_constraint,
             box_constraint=self.box_constraint,
             dim=self.dim,
@@ -341,18 +343,18 @@ class Project:
                 )
 
         def project_and_check(
-            yraw: ProjectionInstance,
+            y_raw: ProjectionInstance,
         ) -> tuple[ProjectionInstance, jax.Array, int]:
             # Executed iterations
             iter_exec = 0
             terminate = False
             # Call the projection function with all given arguments.
-            y0 = self.initialize(yraw)
-            xproj = yraw
+            y0 = self.initialize(y_raw)
+            xproj = y_raw
             while not (terminate or iter_exec >= max_iter):
                 xproj, y = self.call(
                     s0=y0,
-                    yraw=yraw,
+                    y_raw=y_raw,
                     sigma=sigma,
                     omega=omega,
                     n_iter=check_every,
@@ -365,21 +367,21 @@ class Project:
 
         return project_and_check
 
-    def _project_single(self, yraw: ProjectionInstance) -> ProjectionInstance:
+    def _project_single(self, y_raw: ProjectionInstance) -> ProjectionInstance:
         """Project a batch of points with single constraint.
 
         Args:
-            yraw: Point to be projected.
+            y_raw: Point to be projected.
                 Shape (batch_size, dimension, 1).
 
         Returns:
             ProjectionInstance: The projected point for each point in the batch.
         """
-        if yraw.eq and yraw.eq.a_mat is not None:
-            a_mat_pinv = jnp.linalg.pinv(yraw.eq.a_mat)
-            yraw = yraw.update(eq=yraw.eq.update(a_mat_pinv=a_mat_pinv))
+        if y_raw.eq and y_raw.eq.a_mat is not None:
+            a_mat_pinv = jnp.linalg.pinv(y_raw.eq.a_mat)
+            y_raw = y_raw.update(eq=y_raw.eq.update(a_mat_pinv=a_mat_pinv))
 
-        return self.single_constraint.project(yraw)
+        return self.single_constraint.project(y_raw)
 
 
 # Project general
@@ -393,7 +395,7 @@ def _project_general(
     dim_lifted: int,
     d_r: RowScaling,
     d_c: ColScaling,
-    yraw: ProjectionInstance,
+    y_raw: ProjectionInstance,
     s0: ProjectionInstance | None = None,
     sigma: ScalarLike = PROJECTION_DEFAULT_SIGMA,
     omega: ScalarLike = PROJECTION_DEFAULT_OMEGA,
@@ -408,7 +410,7 @@ def _project_general(
         dim_lifted: Dimension of the lifted space.
         d_r: Scaling factor for the rows.
         d_c: Scaling factor for the columns.
-        yraw: Point to be projected.
+        y_raw: Point to be projected.
         s0: Initial value for the governing sequence.
         sigma: ADMM parameter.
         omega: ADMM parameter.
@@ -419,10 +421,10 @@ def _project_general(
     """
     assert n_iter > 0, "Number of iterations must be positive."
 
-    s0 = initialize_fn(yraw) if s0 is None else s0
+    s0 = initialize_fn(y_raw) if s0 is None else s0
     sk, _ = jax.lax.scan(
         lambda s_prev, _: (
-            step_iteration(s_prev, yraw, sigma, omega),
+            step_iteration(s_prev, y_raw, sigma, omega),
             None,
         ),
         s0,
@@ -430,11 +432,11 @@ def _project_general(
         length=n_iter,
     )
 
-    y = step_final(sk).x[:, : yraw.x.shape[1], :]
-    y_scaled = y * d_c[:, : yraw.x.shape[1], :]
+    y = step_final(sk).x[:, : y_raw.x.shape[1], :]
+    y_scaled = y * d_c[:, : y_raw.x.shape[1], :]
 
     # Unscale the output
-    return yraw.update(x=y_scaled), sk
+    return y_raw.update(x=y_scaled), sk
 
 
 @partial(
@@ -459,7 +461,7 @@ def _project_general_custom(
     dim_lifted: int,
     d_r: RowScaling,
     d_c: ColScaling,
-    yraw: ProjectionInstance,
+    y_raw: ProjectionInstance,
     s0: ProjectionInstance | None = None,
     sigma: ScalarLike = PROJECTION_DEFAULT_SIGMA,
     omega: ScalarLike = PROJECTION_DEFAULT_OMEGA,
@@ -475,7 +477,7 @@ def _project_general_custom(
         d_r=d_r,
         d_c=d_c,
         s0=s0,
-        yraw=yraw,
+        y_raw=y_raw,
         sigma=sigma,
         omega=omega,
         n_iter=n_iter,
@@ -492,7 +494,7 @@ def _project_general_fwd(
     dim_lifted: int,
     d_r: RowScaling,
     d_c: ColScaling,
-    yraw: ProjectionInstance,
+    y_raw: ProjectionInstance,
     s0: ProjectionInstance | None = None,
     sigma: ScalarLike = PROJECTION_DEFAULT_SIGMA,
     omega: ScalarLike = PROJECTION_DEFAULT_OMEGA,
@@ -522,7 +524,7 @@ def _project_general_fwd(
             d_r=d_r,
             d_c=d_c,
             s0=s0,
-            yraw=yraw,
+            y_raw=y_raw,
             sigma=sigma,
             omega=omega,
             n_iter=n_iter,
@@ -530,7 +532,7 @@ def _project_general_fwd(
     )
     y, s_k = custom_result
 
-    return (y, s_k), (s_k, yraw, d_r, d_c, sigma, omega)
+    return (y, s_k), (s_k, y_raw, d_r, d_c, sigma, omega)
 
 
 def _project_general_bwd(
@@ -580,18 +582,18 @@ def _project_general_bwd(
     Returns:
         tuple: The computed cotangent for the projection.
     """
-    s_k, yraw, _, d_c, sigma, omega = residuals
+    s_k, y_raw, _, d_c, sigma, omega = residuals
     cotangent_zk1, _ = cotangent
 
     _, iteration_vjp = jax.vjp(
-        lambda xx: step_iteration(xx, yraw, sigma, omega),
+        lambda xx: step_iteration(xx, y_raw, sigma, omega),
         s_k,
     )
-    _, iteration_vjp2 = jax.vjp(lambda xx: step_iteration(s_k, xx, sigma, omega), yraw)
+    _, iteration_vjp2 = jax.vjp(lambda xx: step_iteration(s_k, xx, sigma, omega), y_raw)
     _, equality_vjp = jax.vjp(step_final, s_k)
 
     # Rescale the gradient
-    cotangent_zk1 = cotangent_zk1.x * d_c[:, : yraw.x.shape[1], :]
+    cotangent_zk1 = cotangent_zk1.x * d_c[:, : y_raw.x.shape[1], :]
 
     # Compute VJP of cotangent with projection before auxiliary
     cotangent_eq_6 = equality_vjp(

--- a/src/pinet/solver/admm.py
+++ b/src/pinet/solver/admm.py
@@ -21,7 +21,7 @@ PROJECTION_DEFAULT_OMEGA = Constants.PROJECTION_DEFAULT_OMEGA
 
 
 def initialize(
-    yraw: ProjectionInstance,
+    y_raw: ProjectionInstance,
     ineq_constraint: AffineInequalityConstraint | None,
     box_constraint: BoxConstraint | None,
     dim: int,
@@ -32,7 +32,7 @@ def initialize(
     """Initialize the ADMM solver state.
 
     Args:
-        yraw: Point to be projected.
+        y_raw: Point to be projected.
         ineq_constraint: Inequality constraint.
         box_constraint: Box constraint.
         dim: Dimension of the original problem.
@@ -46,7 +46,7 @@ def initialize(
         Initial state for the ADMM solver.
     """
     # Preprocess
-    eq_spec = yraw.eq
+    eq_spec = y_raw.eq
     # ``a_mat`` is only valid alongside ``b`` (enforced by the spec
     # validators), so checking ``b`` covers both per-instance overrides.
     if eq_spec is not None and eq_spec.b is not None:
@@ -79,10 +79,10 @@ def initialize(
             assert lifted_eq_constraint is not None
             updates["a_mat"] = lifted_eq_constraint.a_mat
             updates["a_mat_pinv"] = lifted_eq_constraint.a_mat_pinv
-        yraw = yraw.update(eq=eq_spec.update(**updates))
+        y_raw = y_raw.update(eq=eq_spec.update(**updates))
 
     # Return updated value
-    return yraw.update(x=jnp.zeros((yraw.x.shape[0], dim_lifted, 1)))
+    return y_raw.update(x=jnp.zeros((y_raw.x.shape[0], dim_lifted, 1)))
 
 
 def build_iteration_step(
@@ -113,7 +113,7 @@ def build_iteration_step(
 
     def iteration_step(
         sk: ProjectionInstance,
-        yraw: ProjectionInstance,
+        y_raw: ProjectionInstance,
         sigma: ScalarLike = PROJECTION_DEFAULT_SIGMA,
         omega: ScalarLike = PROJECTION_DEFAULT_OMEGA,
     ) -> ProjectionInstance:
@@ -121,7 +121,7 @@ def build_iteration_step(
 
         Args:
             sk: State iterate for the ADMM solver.
-            yraw: Point to be projected.
+            y_raw: Point to be projected.
             sigma: ADMM parameter.
             omega: ADMM parameter.
 
@@ -133,7 +133,7 @@ def build_iteration_step(
         reflect = 2 * zk.x - sk.x
         tobox = jnp.concatenate(
             (
-                (2 * sigma * scale * yraw.x + reflect[:, :dim, :])
+                (2 * sigma * scale * y_raw.x + reflect[:, :dim, :])
                 / (1 + 2 * sigma * scale**2),
                 reflect[:, dim:, :],
             ),

--- a/src/test/test_abstract_constraint.py
+++ b/src/test/test_abstract_constraint.py
@@ -23,17 +23,17 @@ from pinet.constraints.non_linear_types import SOCType
 def test_constraint_base_project_raises() -> None:
     """``Constraint.project`` must fail with a named NotImplementedError."""
     c = Constraint()
-    yraw = ProjectionInstance(x=jnp.zeros((1, 1, 1)))
+    y_raw = ProjectionInstance(x=jnp.zeros((1, 1, 1)))
     with pytest.raises(NotImplementedError, match=r"Constraint\.project"):
-        c.project(yraw)
+        c.project(y_raw)
 
 
 def test_constraint_base_cv_raises() -> None:
     """``Constraint.cv`` must fail with a named NotImplementedError."""
     c = Constraint()
-    yraw = ProjectionInstance(x=jnp.zeros((1, 1, 1)))
+    y_raw = ProjectionInstance(x=jnp.zeros((1, 1, 1)))
     with pytest.raises(NotImplementedError, match=r"Constraint\.cv"):
-        c.cv(yraw)
+        c.cv(y_raw)
 
 
 def test_constraint_base_dim_raises() -> None:
@@ -50,8 +50,9 @@ def test_constraint_base_n_constraints_raises() -> None:
         _ = c.n_constraints
 
 
-def _make_nl_parameter_carrier() -> NonLinearConstraint:
-    """Build a minimal valid ``NonLinearConstraint`` parameter carrier."""
+@pytest.fixture
+def nl_parameter_carrier() -> NonLinearConstraint:
+    """Provide a minimal valid ``NonLinearConstraint`` parameter carrier."""
     spec = NonLinearSpecification(
         nl_type=SOCType,
         a_mat=jnp.zeros((1, 1, 2)),
@@ -62,26 +63,29 @@ def _make_nl_parameter_carrier() -> NonLinearConstraint:
     return NonLinearConstraint(spec)
 
 
-def test_nonlinear_constraint_n_constraints_is_one() -> None:
+def test_nonlinear_constraint_n_constraints_is_one(
+    nl_parameter_carrier: NonLinearConstraint,
+) -> None:
     """Direct instantiation of ``NonLinearConstraint`` reports a single constraint."""
-    nl = _make_nl_parameter_carrier()
-    assert nl.n_constraints == 1
+    assert nl_parameter_carrier.n_constraints == 1
 
 
-def test_nonlinear_constraint_project_raises() -> None:
+def test_nonlinear_constraint_project_raises(
+    nl_parameter_carrier: NonLinearConstraint,
+) -> None:
     """``NonLinearConstraint.project`` signals the subclass contract."""
-    nl = _make_nl_parameter_carrier()
-    yraw = ProjectionInstance(x=jnp.zeros((1, 2, 1)))
+    y_raw = ProjectionInstance(x=jnp.zeros((1, 2, 1)))
     with pytest.raises(NotImplementedError, match=r"parameter carrier"):
-        nl.project(yraw)
+        nl_parameter_carrier.project(y_raw)
 
 
-def test_nonlinear_constraint_cv_raises() -> None:
+def test_nonlinear_constraint_cv_raises(
+    nl_parameter_carrier: NonLinearConstraint,
+) -> None:
     """``NonLinearConstraint.cv`` signals the subclass contract."""
-    nl = _make_nl_parameter_carrier()
-    yraw = ProjectionInstance(x=jnp.zeros((1, 2, 1)))
+    y_raw = ProjectionInstance(x=jnp.zeros((1, 2, 1)))
     with pytest.raises(NotImplementedError, match=r"parameter carrier"):
-        nl.cv(yraw)
+        nl_parameter_carrier.cv(y_raw)
 
 
 def test_equality_project_pinv_recomputes_when_pinv_missing() -> None:
@@ -96,11 +100,11 @@ def test_equality_project_pinv_recomputes_when_pinv_missing() -> None:
     eq = EqualityConstraint(a_mat=a_mat, b=b, method="pinv", var_a_mat=True)
 
     x = jnp.array([[[1.0], [2.0], [3.0]]])
-    yraw = ProjectionInstance(
+    y_raw = ProjectionInstance(
         x=x,
         eq=EqualityConstraintsSpecification(a_mat=a_mat, b=b, a_mat_pinv=None),
     )
-    out = eq.project_pinv(yraw)
+    out = eq.project_pinv(y_raw)
     # The first two coordinates must match b exactly after projection.
     assert jnp.allclose(out.x[0, 0, 0], 0.3)
     assert jnp.allclose(out.x[0, 1, 0], -0.4)

--- a/src/test/test_cartesian_constraint.py
+++ b/src/test/test_cartesian_constraint.py
@@ -58,10 +58,10 @@ def test_non_box_soc_constraint_raises():
     class DummyConstraint(Constraint):
         _dim: int = 5
 
-        def project(self, yraw):
-            return yraw
+        def project(self, y_raw):
+            return y_raw
 
-        def cv(self, yraw):
+        def cv(self, y_raw):
             return jnp.zeros((1, 1, 1))
 
         @property
@@ -84,19 +84,19 @@ def test_non_box_soc_constraint_raises():
 
 
 def test_project_raises_when_nl_specs_not_iterable():
-    """Test project raises TypeError if yraw.nl is not a list/tuple."""
+    """Test project raises TypeError if y_raw.nl is not a list/tuple."""
     dim = 6
     soc_mask_u = jnp.array([True, True, False, False, False, False], dtype=jnp.bool_)
     soc_mask_t = jnp.array([False, False, True, False, False, False], dtype=jnp.bool_)
     soc = SocConstraint(SocConstraintSpecification(mask_u=soc_mask_u, mask_t=soc_mask_t))
     cartesian = CartesianConstraint(nl_constraints=[soc])
 
-    # yraw.nl must be list/tuple when nonlinear constraints are present.
+    # y_raw.nl must be list/tuple when nonlinear constraints are present.
     # ProjectionInstance's own __init__ is beartype-checked; constructing the
     # deliberately-malformed instance may raise a TypeCheckError before
     # project() runs. Either error path is acceptable.
     with pytest.raises(_TypeOrValidationError):
-        yraw = ProjectionInstance(
+        y_raw = ProjectionInstance(
             x=jnp.zeros((1, dim, 1)),
             nl=cast(
                 "list[NonLinearSpecification]",
@@ -106,18 +106,18 @@ def test_project_raises_when_nl_specs_not_iterable():
                 ),
             ),
         )
-        cartesian.project(yraw)
+        cartesian.project(y_raw)
 
 
 def test_wrong_dimensions_box_and_soc_raise():
     """Test that Box and SOC constraints with different dimensions raise ValueError."""
     # Create box constraint with dimension 5
-    box_mask = jnp.array([True, True, False, False, False], dtype=jnp.bool_)
+    mask_box = jnp.array([True, True, False, False, False], dtype=jnp.bool_)
     box = BoxConstraint(
         BoxConstraintSpecification(
             lb=jnp.array([[[-1.0], [-1.0]]]),
             ub=jnp.array([[[1.0], [1.0]]]),
-            mask=box_mask,
+            mask=mask_box,
         )
     )
 
@@ -133,12 +133,12 @@ def test_wrong_dimensions_box_and_soc_raise():
 def test_overlapping_box_and_soc_masks_raise():
     """Test that overlapping masks between Box and SOC constraints raise ValueError."""
     # Create box constraint on dimensions 0-1
-    box_mask = jnp.array([True, True, False, False, False], dtype=jnp.bool_)
+    mask_box = jnp.array([True, True, False, False, False], dtype=jnp.bool_)
     box = BoxConstraint(
         BoxConstraintSpecification(
             lb=jnp.array([[[-1.0], [-1.0]]]),
             ub=jnp.array([[[1.0], [1.0]]]),
-            mask=box_mask,
+            mask=mask_box,
         )
     )
 
@@ -203,12 +203,12 @@ def test_random_example_with_two_boxes_two_socs(seed: int, batch_size: int):
 
     # Create non-overlapping masks for 100 dimensions
     # Box 1: dimensions 0-24
-    box_mask_1 = jnp.zeros(DIM, dtype=jnp.bool_)
-    box_mask_1 = box_mask_1.at[0:25].set(True)
+    mask_box_1 = jnp.zeros(DIM, dtype=jnp.bool_)
+    mask_box_1 = mask_box_1.at[0:25].set(True)
 
     # Box 2: dimensions 25-49
-    box_mask_2 = jnp.zeros(DIM, dtype=jnp.bool_)
-    box_mask_2 = box_mask_2.at[25:50].set(True)
+    mask_box_2 = jnp.zeros(DIM, dtype=jnp.bool_)
+    mask_box_2 = mask_box_2.at[25:50].set(True)
 
     # SOC 1: dimensions 50-74 (u) and 75 (t)
     soc_mask_u_1 = jnp.zeros(DIM, dtype=jnp.bool_)
@@ -227,7 +227,7 @@ def test_random_example_with_two_boxes_two_socs(seed: int, batch_size: int):
         BoxConstraintSpecification(
             lb=jnp.array([-box_1_bound] * 25 + [-box_2_bound] * 25).reshape(1, -1, 1),
             ub=jnp.array([box_1_bound] * 25 + [box_2_bound] * 25).reshape(1, -1, 1),
-            mask=jnp.logical_or(box_mask_1, box_mask_2),
+            mask=jnp.logical_or(mask_box_1, mask_box_2),
         )
     )
 
@@ -322,12 +322,12 @@ def test_projection_equivalence(seed, batch_size):
     dim = 10
 
     # Create non-overlapping constraints
-    box_mask = jnp.array([True] * 4 + [False] * 6, dtype=jnp.bool_)
+    mask_box = jnp.array([True] * 4 + [False] * 6, dtype=jnp.bool_)
     box = BoxConstraint(
         BoxConstraintSpecification(
             lb=jnp.array([[[-1.0]] * 4]),
             ub=jnp.array([[[1.0]] * 4]),
-            mask=box_mask,
+            mask=mask_box,
         )
     )
 
@@ -361,12 +361,12 @@ def test_projection_equivalence(seed, batch_size):
 def test_cv():
     """Test that cv returns the maximum violation across all constraints."""
     # Box constraint on dimensions 0-2: [-1, 1]
-    box_mask = jnp.array([True] * 3 + [False] * 7, dtype=jnp.bool_)
+    mask_box = jnp.array([True] * 3 + [False] * 7, dtype=jnp.bool_)
     box = BoxConstraint(
         BoxConstraintSpecification(
             lb=jnp.array([[[-1.0]] * 3]),
             ub=jnp.array([[[1.0]] * 3]),
-            mask=box_mask,
+            mask=mask_box,
         )
     )
 
@@ -442,12 +442,12 @@ def test_projection_with_only_box_constraint(seed: int, batch_size: int):
     key = jrnd.PRNGKey(seed)
     dim = 10
 
-    box_mask = jnp.array(
+    mask_box = jnp.array(
         [True, True, True, True, False, False, False, False, False, False]
     )
     lb = jnp.array([[[-1.0], [-0.5], [-2.0], [-1.5]]])
     ub = jnp.array([[[1.0], [0.5], [2.0], [1.5]]])
-    box = BoxConstraint(BoxConstraintSpecification(lb=lb, ub=ub, mask=box_mask))
+    box = BoxConstraint(BoxConstraintSpecification(lb=lb, ub=ub, mask=mask_box))
 
     cartesian = CartesianConstraint(box_constraint=box, nl_constraints=None)
 

--- a/src/test/test_clipped_affine_sine.py
+++ b/src/test/test_clipped_affine_sine.py
@@ -31,7 +31,7 @@ class HardConstrainedMLP(nn.Module):
         x = nn.softplus(x)
         x = nn.Dense(1)(x)
         x = self.project.call(
-            yraw=ProjectionInstance(x=x.reshape((x.shape[0], x.shape[1], 1))),
+            y_raw=ProjectionInstance(x=x.reshape((x.shape[0], x.shape[1], 1))),
             sigma=sigma,
             omega=omega,
             n_iter=100,
@@ -115,7 +115,7 @@ def test_clipped_sine(seed: int, c_value: float, lb: float, ub: float):
 
     # Clip y to meet the constraints via cvxpy
     projected_y = []
-    for _x, _y in zip(x, y, strict=False):
+    for _x, _y in zip(x, y, strict=True):
         # Create a scalar optimization variable.
         z = cp.Variable()
 

--- a/src/test/test_clipped_sine.py
+++ b/src/test/test_clipped_sine.py
@@ -27,7 +27,7 @@ class HardConstrainedMLP(nn.Module):
         x = nn.relu(x)
         x = nn.Dense(1)(x)
         project = Project(box_constraint=self.box_constraint)
-        x = project.call(yraw=ProjectionInstance(x=x[..., None]))[0].x.squeeze(-1)
+        x = project.call(y_raw=ProjectionInstance(x=x[..., None]))[0].x.squeeze(-1)
         return x
 
 

--- a/src/test/test_constraint_violation.py
+++ b/src/test/test_constraint_violation.py
@@ -110,17 +110,17 @@ def test_inequality_cv():
         ],
         axis=0,
     )
-    yraw = ProjectionInstance(x=x)
+    y_raw = ProjectionInstance(x=x)
 
     gt_cv = jnp.array([3.0, 5.0, 1.0, 3.0]).reshape(-1, 1, 1)
-    ineq_cv = ineq_constraint.cv(yraw)
+    ineq_cv = ineq_constraint.cv(y_raw)
     assert jnp.allclose(ineq_cv, gt_cv), f"Expected {gt_cv}, but got {ineq_cv}."
 
     # Check that the projection has zero cv
     # The inequality constraint does not implement project.
     projection_layer = Project(ineq_constraint=ineq_constraint)
     x_proj = projection_layer.call(
-        yraw=yraw,
+        y_raw=y_raw,
         n_iter=100,
     )[0]
     ineq_cv_proj = ineq_constraint.cv(x_proj)
@@ -135,7 +135,7 @@ def test_inequality_cv():
     lb = jax.random.normal(key[1], shape=(1, m, 1))
     ub = lb + jnp.abs(jax.random.normal(key[2], shape=(1, m, 1)))
     x = jax.random.normal(key[3], shape=(batch_size, n, 1))
-    yraw = ProjectionInstance(x=x)
+    y_raw = ProjectionInstance(x=x)
     ineq_constraint = AffineInequalityConstraint(c_mat, lb, ub)
 
     # Ground truth
@@ -144,13 +144,13 @@ def test_inequality_cv():
         axis=1,
         keepdims=True,
     )
-    ineq_cv = ineq_constraint.cv(yraw)
+    ineq_cv = ineq_constraint.cv(y_raw)
     assert jnp.allclose(ineq_cv, gt_cv), f"Expected {gt_cv}, but got {ineq_cv}."
 
     # Check that the projection has zero cv
     projection_layer = Project(ineq_constraint=ineq_constraint)
     x_proj = projection_layer.call(
-        yraw=yraw,
+        y_raw=y_raw,
         n_iter=100,
     )[0]
     ineq_cv_proj = ineq_constraint.cv(x_proj)
@@ -184,14 +184,14 @@ def test_inequality_box_cv():
         ],
         axis=0,
     )
-    yraw = ProjectionInstance(x=x)
+    y_raw = ProjectionInstance(x=x)
     gt_cv = jnp.array([2.0, 1.5, 0.5 * 2.5 + 1.0 * 1.0 - 1.0]).reshape(-1, 1, 1)
-    cv = projection_layer.cv(y=yraw)
+    cv = projection_layer.cv(y=y_raw)
     assert jnp.allclose(cv, gt_cv), f"Expected {gt_cv}, but got {cv}."
 
     # Check that the projection has zero cv
     x_proj = projection_layer.call(
-        yraw=yraw,
+        y_raw=y_raw,
         n_iter=100,
     )[0]
     cv_proj = projection_layer.cv(x_proj)
@@ -224,7 +224,7 @@ def test_equality_only_cv():
 
     # After projection, cv must be zero.
     # Equality-only is a single-shot projection; one iteration is sufficient.
-    x_proj = projection_layer.call(yraw=y, n_iter=1)[0]
+    x_proj = projection_layer.call(y_raw=y, n_iter=1)[0]
     cv_proj = projection_layer.cv(x_proj)
     assert jnp.allclose(cv_proj, 0.0, atol=1e-6), f"Expected 0.0, but got {cv_proj}."
 
@@ -331,7 +331,7 @@ def test_equality_inequality_box_cv(method, seed, batch_size):
         inp = ProjectionInstance(
             x=x[..., None], eq=EqualityConstraintsSpecification(b=b[ii : ii + 1])
         )
-        x_proj = projection_layer.call(yraw=inp, n_iter=1000)[0]
+        x_proj = projection_layer.call(y_raw=inp, n_iter=1000)[0]
         cv_proj = projection_layer.cv(
             ProjectionInstance(
                 x=x_proj.x[ii : ii + 1],

--- a/src/test/test_equality_2d.py
+++ b/src/test/test_equality_2d.py
@@ -36,7 +36,7 @@ class HardConstrainedMLP(nn.Module):
         x = nn.softplus(x)
         x = nn.Dense(2)(x)
         project = Project(eq_constraint=self.eq_constraint)
-        x = project.call(yraw=ProjectionInstance(x=x[..., None]))[0].x.squeeze(-1)
+        x = project.call(y_raw=ProjectionInstance(x=x[..., None]))[0].x.squeeze(-1)
         return x
 
 

--- a/src/test/test_equilibration.py
+++ b/src/test/test_equilibration.py
@@ -121,16 +121,19 @@ def test_general_eq_ineq(seed, batch_size):
         uboxfeas <= 1,
     ]
     for ii in range(batch_size):
-        constraints += [
-            a_mat[0, :, :] @ xfeas[ii * dim : (ii + 1) * dim]
-            == bfeas[ii * n_eq : (ii + 1) * n_eq],
-            lfeas <= c_mat[0, :, :] @ xfeas[ii * dim : (ii + 1) * dim],
-            c_mat[0, :, :] @ xfeas[ii * dim : (ii + 1) * dim] <= ufeas,
-            lboxfeas <= xfeas[ii * dim : (ii + 1) * dim][mask],
-            xfeas[ii * dim : (ii + 1) * dim][mask] <= uboxfeas,
-            lower_feas_bound <= xfeas,
-            xfeas <= upper_feas_bound,
-        ]
+        constraints += cast(
+            list[CvxpyConstraint],
+            [
+                a_mat[0, :, :] @ xfeas[ii * dim : (ii + 1) * dim]
+                == bfeas[ii * n_eq : (ii + 1) * n_eq],
+                lfeas <= c_mat[0, :, :] @ xfeas[ii * dim : (ii + 1) * dim],
+                c_mat[0, :, :] @ xfeas[ii * dim : (ii + 1) * dim] <= ufeas,
+                lboxfeas <= xfeas[ii * dim : (ii + 1) * dim][mask],
+                xfeas[ii * dim : (ii + 1) * dim][mask] <= uboxfeas,
+                lower_feas_bound <= xfeas,
+                xfeas <= upper_feas_bound,
+            ],
+        )
     objective = cp.Minimize(jnp.ones(shape=(dim * batch_size)) @ xfeas)
     problem = cp.Problem(objective=objective, constraints=constraints)
     problem.solve(verbose=False)

--- a/src/test/test_equilibration.py
+++ b/src/test/test_equilibration.py
@@ -213,15 +213,15 @@ def test_general_eq_ineq(seed, batch_size):
         inp = ProjectionInstance(
             x=x[..., None], eq=EqualityConstraintsSpecification(b=b) if var_b else None
         )
-        y_unroll = pl_unroll.call(yraw=inp, n_iter=n_iter, sigma=sigma, omega=omega)[0]
+        y_unroll = pl_unroll.call(y_raw=inp, n_iter=n_iter, sigma=sigma, omega=omega)[0]
         y_impl = pl_unroll_equil.call(
-            yraw=inp,
+            y_raw=inp,
             n_iter=n_iter,
             sigma=sigma_equil,
             omega=omega,
         )[0]
         y_impl_equil = pl_impl_equil.call(
-            yraw=inp,
+            y_raw=inp,
             n_iter=n_iter,
             sigma=sigma_equil,
             omega=omega,
@@ -256,12 +256,28 @@ def test_general_eq_ineq(seed, batch_size):
             omega=omega,
         )
 
-        def loss(x, v, inputs: LossInputs, options: LossOptions):
+        def loss(
+            x: jax.Array,
+            v: jax.Array,
+            inputs: LossInputs,
+            options: LossOptions,
+        ) -> jax.Array:
+            """Project ``x`` under one solver mode and return a scalar loss.
+
+            Args:
+                x: Point to project.
+                v: Direction vector contracted with the projected output.
+                inputs: Shared projection layers, RHS, and solver settings.
+                options: Selects the solver mode and backward-pass settings.
+
+            Returns:
+                The mean of ``proj(x) @ v`` for the selected mode.
+            """
             inp = inputs.projection_input(x)
             if options.mode == "unroll":
                 return (
                     inputs.pl_unroll.call(
-                        yraw=inp,
+                        y_raw=inp,
                         n_iter=inputs.n_iter,
                         sigma=inputs.sigma,
                         omega=inputs.omega,
@@ -271,7 +287,7 @@ def test_general_eq_ineq(seed, batch_size):
             elif options.mode == "unroll_equil":
                 return (
                     inputs.pl_unroll_equil.call(
-                        yraw=inp,
+                        y_raw=inp,
                         n_iter=inputs.n_iter,
                         sigma=inputs.sigma_equil,
                         omega=inputs.omega,
@@ -281,7 +297,7 @@ def test_general_eq_ineq(seed, batch_size):
             elif options.mode == "impl_equil":
                 return (
                     inputs.pl_impl_equil.call(
-                        yraw=inp,
+                        y_raw=inp,
                         n_iter=inputs.n_iter,
                         sigma=inputs.sigma_equil,
                         omega=inputs.omega,
@@ -290,6 +306,7 @@ def test_general_eq_ineq(seed, batch_size):
                     )[0].x[..., 0]
                     @ v
                 ).mean()
+            raise ValueError(f"Unknown loss mode: {options.mode}")
 
         grad_unroll = jax.grad(loss, argnums=0)(
             x, vec, loss_inputs, LossOptions(mode="unroll")

--- a/src/test/test_parser_and_nonlinear.py
+++ b/src/test/test_parser_and_nonlinear.py
@@ -1,3 +1,10 @@
+"""Tests for the constraint parser with non-linear constraints.
+
+Covers parsing and projection when non-linear constraints (L2-norm / SOC
+types) are combined with equality, inequality, and box constraints,
+including the ``var_a_mat=True`` per-instance path.
+"""
+
 from itertools import product
 from typing import cast
 
@@ -144,7 +151,7 @@ def test_simple_problem(seed, batch_size):
         :, n_a:, dim:
     ].set(-jnp.eye(n_extra))
     b_lifted_correct = jnp.concatenate([b, jnp.zeros((1, n_extra, 1))], axis=1)
-    box_mask_correct = jnp.concatenate(
+    mask_box_correct = jnp.concatenate(
         [mask, jnp.array([True] * n_c + [False] * (n_extra - n_c), dtype=jnp.bool_)]
     )
     box_ub_correct = jnp.concatenate([ub_box, ub_ineq], axis=1)
@@ -178,7 +185,7 @@ def test_simple_problem(seed, batch_size):
     box_first = cart_lifted.constraints[0]
     assert isinstance(box_first, BoxConstraint)
     assert box_first.lb is not None and box_first.ub is not None
-    assert jnp.allclose(box_first.mask, box_mask_correct), """
+    assert jnp.allclose(box_first.mask, mask_box_correct), """
         Box mask is incorrect.
     """
     assert jnp.allclose(box_first.ub, box_ub_correct), """
@@ -209,7 +216,7 @@ def test_simple_problem(seed, batch_size):
     # Create random points to be projected
     key, subkey = jrnd.split(key)
     yproj = jrnd.uniform(subkey, shape=(batch_size, dim, 1), minval=-5, maxval=5)
-    yraw = ProjectionInstance(x=yproj, nl=[nlspec_1, nlspec_2])
+    y_raw = ProjectionInstance(x=yproj, nl=[nlspec_1, nlspec_2])
 
     # Build the algorithm
     n_iter = 1500
@@ -223,7 +230,7 @@ def test_simple_problem(seed, batch_size):
         x=jnp.zeros((batch_size, dim + n_extra, 1)), nl=[nlspec_1, nlspec_2]
     )
     for _ii in range(n_iter):
-        sk = iteration_step(sk=sk, yraw=yraw, sigma=0.1, omega=1.8)
+        sk = iteration_step(sk=sk, y_raw=y_raw, sigma=0.1, omega=1.8)
     yk = final_step(sk)
 
     # Compute projection with cvxpy
@@ -273,12 +280,12 @@ def test_simple_problem(seed, batch_size):
         - f_soc_2 @ x_feas
     )
     nlspec_2_new = nlspec_2.update(a=a_soc_2_new, b=b_soc_2_new)
-    yraw_new = ProjectionInstance(x=yproj, nl=[nlspec_1, nlspec_2_new])
+    y_raw_new = ProjectionInstance(x=yproj, nl=[nlspec_1, nlspec_2_new])
     sk = ProjectionInstance(
         x=jnp.zeros((batch_size, dim + n_extra, 1)), nl=[nlspec_1, nlspec_2_new]
     )
     for _ii in range(n_iter):
-        sk = iteration_step(sk=sk, yraw=yraw_new, sigma=0.1, omega=1.8)
+        sk = iteration_step(sk=sk, y_raw=y_raw_new, sigma=0.1, omega=1.8)
     yk_new = final_step(sk)
 
     # CVXPY solution with updated SOC parameters
@@ -352,8 +359,8 @@ def test_parse_non_linear_with_no_box_constraint():
     assert isinstance(cart_lifted, CartesianConstraint)
     assert cart_lifted.box_constraint is not None
 
-    yraw = ProjectionInstance(x=x_ref, nl=[nl_spec])
-    lifted = lift_fn(yraw)
+    y_raw = ProjectionInstance(x=x_ref, nl=[nl_spec])
+    lifted = lift_fn(y_raw)
     assert lifted.x.shape[1] > dim
 
 
@@ -391,8 +398,8 @@ def test_parse_non_linear_l2_norm_projection(seed: int, batch_size: int):
 
     # Project a random batch and confirm the L2 ball constraint is satisfied.
     x = jrnd.uniform(kx, shape=(batch_size, dim, 1), minval=-3.0, maxval=3.0)
-    yraw = ProjectionInstance(x=x, nl=[nl_spec])
-    y_lifted = lift_fn(yraw)
+    y_raw = ProjectionInstance(x=x, nl=[nl_spec])
+    y_lifted = lift_fn(y_raw)
 
     iteration_step, final_step = build_iteration_step(
         eq_constraint=eq_lifted,
@@ -406,7 +413,7 @@ def test_parse_non_linear_l2_norm_projection(seed: int, batch_size: int):
         nl=[nl_spec],
     )
     for _ in range(300):
-        sk = iteration_step(sk=sk, yraw=yraw, sigma=0.5, omega=1.7)
+        sk = iteration_step(sk=sk, y_raw=y_raw, sigma=0.5, omega=1.7)
 
     yk = final_step(sk)
 
@@ -493,8 +500,8 @@ def test_only_nonlinear_constraints(seed, batch_size):
 
     # Build a random batch and run the ADMM projection loop.
     x = jrnd.uniform(kx, shape=(batch_size, dim, 1), minval=-3, maxval=3)
-    yraw = ProjectionInstance(x=x, nl=[nl_spec])
-    y_lifted = lift_fn(yraw)
+    y_raw = ProjectionInstance(x=x, nl=[nl_spec])
+    y_lifted = lift_fn(y_raw)
 
     iteration_step, final_step = build_iteration_step(
         eq_constraint=eq_lifted,
@@ -508,7 +515,7 @@ def test_only_nonlinear_constraints(seed, batch_size):
         nl=[nl_spec],
     )
     for _ in range(200):
-        sk = iteration_step(sk=sk, yraw=yraw, sigma=0.5, omega=1.7)
+        sk = iteration_step(sk=sk, y_raw=y_raw, sigma=0.5, omega=1.7)
 
     yk = final_step(sk)
 
@@ -568,8 +575,8 @@ def test_box_and_nonlinear_constraints(seed, batch_size):
 
     # Build a random batch
     x = jrnd.uniform(kx, shape=(batch_size, dim, 1), minval=-1.5, maxval=1.5)
-    yraw = ProjectionInstance(x=x, nl=[nl_spec])
-    y_lifted = lift_fn(yraw)
+    y_raw = ProjectionInstance(x=x, nl=[nl_spec])
+    y_lifted = lift_fn(y_raw)
 
     iteration_step, final_step = build_iteration_step(
         eq_constraint=eq_lifted,
@@ -583,7 +590,7 @@ def test_box_and_nonlinear_constraints(seed, batch_size):
         nl=[nl_spec],
     )
     for _ in range(200):
-        sk = iteration_step(sk=sk, yraw=yraw, sigma=0.5, omega=1.7)
+        sk = iteration_step(sk=sk, y_raw=y_raw, sigma=0.5, omega=1.7)
 
     yk = final_step(sk)
 
@@ -593,7 +600,7 @@ def test_box_and_nonlinear_constraints(seed, batch_size):
 
 
 @pytest.mark.parametrize("seed, batch_size", product(SEEDS, [1, 5]))
-def test_project_var_a_dyn_with_nonlinear(seed: int, batch_size: int):
+def test_project_var_a_mat_with_nonlinear(seed: int, batch_size: int):
     """``var_a_mat=True`` works on the non-linear path.
 
     The lifted ``a_mat`` propagates the user-supplied per-instance
@@ -637,7 +644,7 @@ def test_project_var_a_dyn_with_nonlinear(seed: int, batch_size: int):
     nl_constraint = NonLinearConstraint(spec=nl_spec)
 
     # Construct ``Project`` with ``var_a_mat=True`` so the per-instance
-    # ``a_mat`` is supplied at projection time via ``yraw.eq``.
+    # ``a_mat`` is supplied at projection time via ``y_raw.eq``.
     eq_constraint = EqualityConstraint(
         a_mat=a_mat, b=b_eq, method="pinv", var_a_mat=True, var_b=True
     )
@@ -648,12 +655,12 @@ def test_project_var_a_dyn_with_nonlinear(seed: int, batch_size: int):
 
     # Project an infeasible point.
     x_infeas = jrnd.uniform(kxinfeas, shape=(batch_size, dim, 1), minval=-3.0, maxval=3.0)
-    yraw = ProjectionInstance(
+    y_raw = ProjectionInstance(
         x=x_infeas,
         eq=EqualityConstraintsSpecification(a_mat=a_mat, b=b_eq),
         nl=[nl_spec],
     )
-    yk, _ = project_layer.call(yraw=yraw, n_iter=500)
+    yk, _ = project_layer.call(y_raw=y_raw, n_iter=500)
     primal = yk.x[:, :dim, :]
 
     # Equality holds.

--- a/src/test/test_project.py
+++ b/src/test/test_project.py
@@ -32,7 +32,7 @@ BATCH_SIZE = [1, 5]
 
 # TODO: Add another test where var_a_mat, var_b are false.
 @pytest.mark.parametrize("seed, batch_size", product(SEEDS, BATCH_SIZE))
-def test_project_eq_ineq_var_a_dyn_varb(seed, batch_size):
+def test_project_eq_ineq_var_a_mat_varb(seed, batch_size):
     dim = 100
     n_eq = 40
     n_ineq = 50
@@ -61,7 +61,7 @@ def test_project_eq_ineq_var_a_dyn_varb(seed, batch_size):
     eq_constraint = EqualityConstraint(a_mat, b, method="pinv", var_b=True)
     projection_layer = Project(eq_constraint=eq_constraint)
     yprojiter = projection_layer.call(
-        yraw=ProjectionInstance(
+        y_raw=ProjectionInstance(
             x=xinfeas[..., None], eq=EqualityConstraintsSpecification(b=b)
         )
     )[0].x
@@ -73,7 +73,7 @@ def test_project_eq_ineq_var_a_dyn_varb(seed, batch_size):
     # Generate new RHS
     b_new = a_mat @ jax.random.normal(key[3], (batch_size, dim, 1))
     yprojiter = projection_layer.call(
-        yraw=ProjectionInstance(
+        y_raw=ProjectionInstance(
             x=xinfeas[..., None], eq=EqualityConstraintsSpecification(b=b_new)
         )
     )[0].x
@@ -133,7 +133,7 @@ def test_project_eq_ineq_var_a_dyn_varb(seed, batch_size):
     )
 
     xprojiter_novarb = projection_layer_novarb.call(
-        yraw=ProjectionInstance(x=xinfeas[..., None]),
+        y_raw=ProjectionInstance(x=xinfeas[..., None]),
         n_iter=500,
     )[0].x
     # Check projection layer with var_b
@@ -146,7 +146,7 @@ def test_project_eq_ineq_var_a_dyn_varb(seed, batch_size):
     inp_varb = ProjectionInstance(
         x=xinfeas[..., None], eq=EqualityConstraintsSpecification(b=b)
     )
-    xprojiter = projection_layer.call(yraw=inp_varb, n_iter=500)[0].x
+    xprojiter = projection_layer.call(y_raw=inp_varb, n_iter=500)[0].x
 
     # Compute projections with QP
     yqp = jnp.zeros(shape=(batch_size, dim))
@@ -235,30 +235,30 @@ def test_project_eq_ineq_var_a_dyn_varb(seed, batch_size):
         "Projection input for the variable-b case should contain equality data."
     )
     inp_varb_new = inp_varb.update(eq=inp_varb.eq.update(b=b_new))
-    xprojiter = projection_layer.call(yraw=inp_varb_new, n_iter=500)[0].x
+    xprojiter = projection_layer.call(y_raw=inp_varb_new, n_iter=500)[0].x
     assert jnp.allclose(xprojiter[..., 0], yqp, atol=1e-3, rtol=1e-3), (
         "Project should match the QP solution after updating the equality RHS. "
         f"Expected {yqp}, got {xprojiter[..., 0]}."
     )
     # %%
     # Generate new LHS and RHS
-    a_dyn_new = jax.random.normal(key[6], (batch_size, n_eq, dim))
-    b_new = a_dyn_new @ jax.random.normal(key[7], (batch_size, dim, 1))
+    a_mat_new = jax.random.normal(key[6], (batch_size, n_eq, dim))
+    b_new = a_mat_new @ jax.random.normal(key[7], (batch_size, dim, 1))
     eq_constraint = EqualityConstraint(
-        a_mat=a_dyn_new, b=b_new, method=method, var_a_mat=True
+        a_mat=a_mat_new, b=b_new, method=method, var_a_mat=True
     )
     projection_layer = Project(eq_constraint=eq_constraint)
     inp = ProjectionInstance(
         x=xinfeas[..., None],
-        eq=EqualityConstraintsSpecification(a_mat=a_dyn_new, b=b_new),
+        eq=EqualityConstraintsSpecification(a_mat=a_mat_new, b=b_new),
     )
-    xprojiter = projection_layer.call(yraw=inp)[0].x
+    xprojiter = projection_layer.call(y_raw=inp)[0].x
     # New cvxpy problem
     yqp = jnp.zeros(shape=(batch_size, dim))
     for ii in range(batch_size):
         yprojcv = cp.Variable(dim)
         constraints_new = cast(
-            list[CvxConstraint], [a_dyn_new[ii, :, :] @ yprojcv == b_new[ii, :, 0]]
+            list[CvxConstraint], [a_mat_new[ii, :, :] @ yprojcv == b_new[ii, :, 0]]
         )
         objective_new = cp.Minimize(cp.sum_squares(yprojcv - xinfeas[ii, :]))
         problem_new = cp.Problem(objective_new, constraints_new)
@@ -276,7 +276,7 @@ def test_project_eq_ineq_var_a_dyn_varb(seed, batch_size):
         constraints = cast(
             list[CvxConstraint],
             [
-                a_dyn_new[ii, :, :] @ yproj == b_new[ii, :, 0],
+                a_mat_new[ii, :, :] @ yproj == b_new[ii, :, 0],
                 lb[ii, :, 0] <= c_mat[ii, :, :] @ yproj,
                 c_mat[ii, :, :] @ yproj <= ub[ii, :, 0],
             ],
@@ -296,9 +296,9 @@ def test_project_eq_ineq_var_a_dyn_varb(seed, batch_size):
     )
     inp = ProjectionInstance(
         x=xinfeas[..., None],
-        eq=EqualityConstraintsSpecification(b=b_new, a_mat=a_dyn_new),
+        eq=EqualityConstraintsSpecification(b=b_new, a_mat=a_mat_new),
     )
-    xprojiter = projection_layer.call(yraw=inp, n_iter=500)[0].x
+    xprojiter = projection_layer.call(y_raw=inp, n_iter=500)[0].x
 
     assert jnp.allclose(xprojiter.reshape(yqp.shape), yqp, atol=1e-3, rtol=1e-3), (
         "Project should match the QP solution when both equality and inequality "
@@ -308,7 +308,7 @@ def test_project_eq_ineq_var_a_dyn_varb(seed, batch_size):
 
 def test_call_default_n_iter_projects_correctly():
     """Regression test for PR #94: default n_iter was 0,
-       causing call() to return yraw unchanged.
+       causing call() to return y_raw unchanged.
 
     With n_iter=0 the scan was skipped and the raw input was returned without
     projecting. The fix sets the default to 100 and adds an assertion, so calling call()
@@ -330,7 +330,7 @@ def test_call_default_n_iter_projects_correctly():
     layer = Project(eq_constraint=eq)
 
     # Call without specifying n_iter — uses the default (100 after the fix, 0 before)
-    result = layer.call(yraw=ProjectionInstance(x=xinfeas))[0].x
+    result = layer.call(y_raw=ProjectionInstance(x=xinfeas))[0].x
 
     # The projected point must satisfy the equality constraint
     residual = jnp.linalg.norm(a_mat @ result - b)
@@ -361,7 +361,7 @@ def test_call_n_iter_zero_raises():
     xinfeas = jax.random.normal(kx, (batch, dim, 1))
 
     with pytest.raises(AssertionError, match=r"Number of iterations must be positive"):
-        layer.call(yraw=ProjectionInstance(x=xinfeas), n_iter=0)
+        layer.call(y_raw=ProjectionInstance(x=xinfeas), n_iter=0)
 
 
 @pytest.mark.parametrize("bad_reduction", ["median", 1.5, 0.0, -0.2, 2])
@@ -369,9 +369,9 @@ def test_call_and_check_invalid_reduction_raises(bad_reduction):
     # Minimal feasible setup: a_mat x = b with b constructed from a random x0
     dim, n_eq, batch = 5, 2, 1
     key = jax.random.PRNGKey(0)
-    k_a_dyn, kx0, kx = jax.random.split(key, 3)
+    ka_mat, kx0, kx = jax.random.split(key, 3)
 
-    a_mat = jax.random.normal(k_a_dyn, (batch, n_eq, dim))
+    a_mat = jax.random.normal(ka_mat, (batch, n_eq, dim))
     x0 = jax.random.normal(kx0, (batch, dim, 1))
     b = a_mat @ x0
 
@@ -414,10 +414,10 @@ def test_project_cv_linear_constraints(seed):
     )
 
     xinfeas = jnp.ones((1, dim, 1)) * 3.0
-    yraw = ProjectionInstance(x=xinfeas)
+    y_raw = ProjectionInstance(x=xinfeas)
 
-    cv_layer = layer.cv(yraw)
-    y_lifted = layer.lift(yraw)
+    cv_layer = layer.cv(y_raw)
+    y_lifted = layer.lift(y_raw)
     # The non-simple polytope path always populates these lifted attributes.
     assert layer.lifted_eq_constraint is not None
     assert layer.lifted_primitive_constraint is not None
@@ -475,10 +475,10 @@ def test_project_cv_nonlinear_constraints(seed):
     )
 
     xinfeas = jnp.ones((1, dim, 1)) * 2.0
-    yraw = ProjectionInstance(x=xinfeas, nl=[nl_spec])
+    y_raw = ProjectionInstance(x=xinfeas, nl=[nl_spec])
 
-    cv_layer = layer.cv(yraw)
-    y_lifted = layer.lift(yraw)
+    cv_layer = layer.cv(y_raw)
+    y_lifted = layer.lift(y_raw)
     # The non-linear path always populates these lifted attributes.
     assert layer.lifted_eq_constraint is not None
     assert layer.lifted_primitive_constraint is not None
@@ -586,13 +586,13 @@ def test_project_box_ineq_eq_soc(seed, batch_size):
     # Generate points to be projected
     key, subkey = jrnd.split(key)
     yproj = jrnd.uniform(subkey, shape=(batch_size, dim, 1), minval=-5, maxval=5)
-    yraw = ProjectionInstance(x=yproj, nl=[nl_spec_1, nl_spec_2])
+    y_raw = ProjectionInstance(x=yproj, nl=[nl_spec_1, nl_spec_2])
 
     # Run projection
     n_iter = 5000
     sigma = 5.0
     omega = 1.7
-    yk, sk = projection_layer.call(yraw=yraw, n_iter=n_iter, sigma=sigma, omega=omega)
+    yk, sk = projection_layer.call(y_raw=y_raw, n_iter=n_iter, sigma=sigma, omega=omega)
 
     # Compute projection with cvxpy
     y_cvxpy = cp.Variable(dim)
@@ -684,9 +684,9 @@ def test_project_box_ineq_eq_soc(seed, batch_size):
         f=f_soc_2,
         b=b_soc_2_new,
     )
-    yraw_new = yraw.update(nl=[nl_spec_1_new, nl_spec_2_new])
+    y_raw_new = y_raw.update(nl=[nl_spec_1_new, nl_spec_2_new])
     yk_new, sk_new = projection_layer.call(
-        yraw=yraw_new, n_iter=n_iter, sigma=sigma, omega=omega
+        y_raw=y_raw_new, n_iter=n_iter, sigma=sigma, omega=omega
     )
 
     y_opt_new = jnp.zeros((batch_size, dim, 1))

--- a/src/test/test_soc.py
+++ b/src/test/test_soc.py
@@ -114,7 +114,7 @@ def test_soc_a_b_parametrized(seed, batch_size):
     mask_t = jnp.zeros((DIM), dtype=jnp.bool_).at[active_dims].set(True)
     socspec = SocConstraintSpecification(mask_u=mask_u, mask_t=mask_t)
     soc_constraint = SocConstraint(socspec=socspec)
-    project_soc = jax.jit(lambda yraw: soc_constraint.project(yraw=yraw).x)
+    project_soc = jax.jit(lambda y_raw: soc_constraint.project(y_raw=y_raw).x)
     z = project_soc(ProjectionInstance(x=x))
 
     assert jnp.allclose(ysocp, z)

--- a/src/test/test_vjp.py
+++ b/src/test/test_vjp.py
@@ -144,7 +144,7 @@ def test_triangle():
     def fun_layer(x, v, fpi):
         return (
             projection_layer.call(
-                yraw=ProjectionInstance(x=x[..., None]),
+                y_raw=ProjectionInstance(x=x[..., None]),
                 sigma=sigma,
                 omega=omega,
                 n_iter=100,
@@ -244,7 +244,7 @@ def test_box():
 
     def fun_layer(x, v):
         return (
-            projection_layer.call(yraw=ProjectionInstance(x=x[..., None]))[0].x[..., 0]
+            projection_layer.call(y_raw=ProjectionInstance(x=x[..., None]))[0].x[..., 0]
             @ v
         ).mean()
 
@@ -307,14 +307,14 @@ def common_vjp_checks(
         if unroll:
             return (
                 projection_layer_unroll.call(
-                    yraw=inp, n_iter=n_iter, sigma=sigma, omega=omega
+                    y_raw=inp, n_iter=n_iter, sigma=sigma, omega=omega
                 )[0].x[..., 0]
                 @ v
             ).mean()
         else:
             return (
                 projection_layer_impl.call(
-                    yraw=inp,
+                    y_raw=inp,
                     n_iter=n_iter,
                     n_iter_bwd=n_iter_bwd,
                     fpi=fpi,
@@ -382,7 +382,7 @@ def common_vjp_checks(
     # Use jax utils for checking
     def unroll_f(y):
         return projection_layer_unroll.call(
-            yraw=ProjectionInstance(x=y, nl=nlspec),
+            y_raw=ProjectionInstance(x=y, nl=nlspec),
             n_iter=n_iter,
             sigma=sigma,
             omega=omega,
@@ -390,7 +390,7 @@ def common_vjp_checks(
 
     def fpi_f(y):
         return projection_layer_impl.call(
-            yraw=ProjectionInstance(x=y, nl=nlspec),
+            y_raw=ProjectionInstance(x=y, nl=nlspec),
             n_iter=n_iter,
             n_iter_bwd=n_iter_bwd,
             fpi=True,
@@ -400,7 +400,7 @@ def common_vjp_checks(
 
     def linsys_f(y):
         return projection_layer_impl.call(
-            yraw=ProjectionInstance(x=y, nl=nlspec),
+            y_raw=ProjectionInstance(x=y, nl=nlspec),
             n_iter=n_iter,
             n_iter_bwd=n_iter_bwd,
             fpi=False,
@@ -439,10 +439,10 @@ def test_general_eq_ineq(seed, batch_size):
     bfeas = cp.Variable(n_eq)
     lfeas = cp.Variable(n_ineq)
     ufeas = cp.Variable(n_ineq)
-    a_dyn_cvx = cp.Constant(np.asarray(a_mat[0, :, :]))
+    a_mat_cvx = cp.Constant(np.asarray(a_mat[0, :, :]))
     constr_matrix_cvx = cp.Constant(np.asarray(c_mat[0, :, :]))
     feasibility_constraints: list[CvxpyConstraint] = [
-        a_dyn_cvx @ xfeas == bfeas,
+        a_mat_cvx @ xfeas == bfeas,
         lfeas <= constr_matrix_cvx @ xfeas,
         constr_matrix_cvx @ xfeas <= ufeas,
         -1 <= xfeas,
@@ -484,7 +484,7 @@ def test_general_eq_ineq(seed, batch_size):
         qp_constraints = cast(
             list[CvxpyConstraint],
             [
-                a_dyn_cvx @ yproj == np.asarray(b[0, :, 0]),
+                a_mat_cvx @ yproj == np.asarray(b[0, :, 0]),
                 np.asarray(lb[0, :, 0]) <= constr_matrix_cvx @ yproj,
                 constr_matrix_cvx @ yproj <= np.asarray(ub[0, :, 0]),
             ],
@@ -499,11 +499,11 @@ def test_general_eq_ineq(seed, batch_size):
     # Check that the projection are computed correctly
     n_iter = 200
     y_unroll = projection_layer_unroll.call(
-        yraw=ProjectionInstance(x=x[..., None]),
+        y_raw=ProjectionInstance(x=x[..., None]),
         n_iter=n_iter,
     )[0].x[..., 0]
     y_impl = projection_layer_impl.call(
-        yraw=ProjectionInstance(x=x[..., None]),
+        y_raw=ProjectionInstance(x=x[..., None]),
         n_iter=n_iter,
     )[0].x[..., 0]
     assert jnp.allclose(y_unroll, yqp, atol=1e-4, rtol=1e-4), (

--- a/src/tools/autotuning.py
+++ b/src/tools/autotuning.py
@@ -276,10 +276,10 @@ def project(
     Returns:
         Projected instance and updated solver state.
     """
-    yraw = ProjectionInstance(x=x, eq=EqualityConstraintsSpecification(b=b))
+    y_raw = ProjectionInstance(x=x, eq=EqualityConstraintsSpecification(b=b))
     return projection_layer.call(
         s0=init,
-        yraw=yraw,
+        y_raw=y_raw,
         sigma=sigma,
         omega=omega,
         n_iter=n_iter,

--- a/uv.lock
+++ b/uv.lock
@@ -1308,6 +1308,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/a8/97ef0cbb7a17143ace2643d600a7b80d6705b2266fc31078229e406bdef2/jax-0.6.2-py3-none-any.whl", hash = "sha256:bb24a82dc60ccf704dcaf6dbd07d04957f68a6c686db19630dd75260d1fb788c", size = 2722396, upload-time = "2025-06-17T23:10:25.293Z" },
 ]
 
+[package.optional-dependencies]
+cuda12 = [
+    { name = "jax-cuda12-plugin", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, extra = ["with-cuda"], marker = "python_full_version < '3.11'" },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+
 [[package]]
 name = "jax"
 version = "0.9.2"
@@ -1327,6 +1333,172 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/4c/5aca25abd45fa38dd136e5ae2010376518c67950e1f9408e0c5c93fcf77d/jax-0.9.2.tar.gz", hash = "sha256:42b28017b3e6b57a44b0274cc15f5153239c4873959030399ac1afc009c22365", size = 2662784, upload-time = "2026-03-18T23:28:10.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/9c/e897231c880f69e32251d3b1145894d7a04e4342d9bef8d29644c440d11b/jax-0.9.2-py3-none-any.whl", hash = "sha256:822a8ae155ab42e7bc59f2ae7a28705bcfccb01a7e76abfc8ae996190cdc5598", size = 3099142, upload-time = "2026-03-18T23:25:59.94Z" },
+]
+
+[package.optional-dependencies]
+cuda12 = [
+    { name = "jax-cuda12-plugin", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, extra = ["with-cuda"], marker = "python_full_version >= '3.11'" },
+    { name = "jaxlib", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+cuda13 = [
+    { name = "jax-cuda13-plugin", extra = ["with-cuda"], marker = "python_full_version >= '3.11'" },
+    { name = "jaxlib", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+
+[[package]]
+name = "jax-cuda12-pjrt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/8b/096a12d91b1bc76a13cd8e63f2d8eae5ca9b5693b5ee2687e46be3b5d779/jax_cuda12_pjrt-0.6.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:22faf020d2e8f7ca1e2915633241f7df7678b73c7078f5f0b2f113248337f7de", size = 111228681, upload-time = "2025-06-17T23:11:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8e/21c21b4335fce1c022c339da5e6b6249c246ad062e924d28fb0eda4bcef0/jax_cuda12_pjrt-0.6.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:8cd9ead7948ea2c778a508fef5d1159e8b7abf4fccc7037c3fe1dbfcd95012dc", size = 125263999, upload-time = "2025-06-17T23:11:59.986Z" },
+]
+
+[[package]]
+name = "jax-cuda12-pjrt"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/f2/ad78d42f27b5af2c59ba7f5412e625bc852280b78a73273b38a4967d6ee1/jax_cuda12_pjrt-0.9.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:56f4a27e5f19ca914c0f4402539469aa92d01bf71336acd0ed8fddc20a91bc8d", size = 151906408, upload-time = "2026-03-18T23:26:03.302Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/06/f097339e873f12f79bc46e15f6e32bba5ab46d62c1a6e25b5e79bc58dbbc/jax_cuda12_pjrt-0.9.2-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:536a305292276c5745efbba7eb57576849c5a7c77398a3a9e61fd31baf5102f0", size = 157876858, upload-time = "2026-03-18T23:26:08.722Z" },
+]
+
+[[package]]
+name = "jax-cuda12-plugin"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "jax-cuda12-pjrt", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/29/4b8822ca459da39bda9be7454908ae4e29d88cfb99b480b641cbb063af7a/jax_cuda12_plugin-0.6.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:bc5c3a75d05519b4d326e4669d0f7ad0fe0f0acf875f9313d913748ccca5a9ea", size = 15873729, upload-time = "2025-06-17T23:12:05.046Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/3d/f543bab6ef7eebb9840d618fb2272bdcc0e990e60aa012f14a3564532823/jax_cuda12_plugin-0.6.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:1751f88989269b3cdb0dfe4f7b072a6442149818c9bc98c3a395c8acaf910a79", size = 15879965, upload-time = "2025-06-17T23:12:07.323Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/99/90f81c660bf662698be17e8b959d8302682c5cd5ce0729c0bfc883d8affe/jax_cuda12_plugin-0.6.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:2cd8e279a59a38ba0c978a831e13adeb6ee9e4572fba387c7975ba3ad535dd38", size = 15873970, upload-time = "2025-06-17T23:12:09.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/00/e733c87a2fb7265c96f48c991a896552c873de949217823d519288724d91/jax_cuda12_plugin-0.6.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:0896cbb308d95291e205cd89d254029dee3a1df43d66e9831331a9afd2d27870", size = 15879563, upload-time = "2025-06-17T23:12:11.439Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/53/6ea0db7230ac3dcb26b732452f4f2e2c6868b75d3603be19cee388fef279/jax_cuda12_plugin-0.6.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:6c9b002d13b1fcb9403713eedd3876a227ad1ffbdfb3811b1f9f89af4c25a5f7", size = 15867462, upload-time = "2025-06-17T23:12:14.093Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/db/e6643143caf573273eedb991cb1af2bea964b84594a8887802eb0b6ba64a/jax_cuda12_plugin-0.6.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:febd099f970d350eb8fa5a2c9a2fb4b0ea7b3d6a89df1496663edfa7afe590e5", size = 15876401, upload-time = "2025-06-17T23:12:15.964Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/10/74fbae1c1bb9d11b113c62e03c445bdf0aaaa4981bc13d2de8e3f4f503ca/jax_cuda12_plugin-0.6.2-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:773efa8b55a837406c561f0ef02144dda9019181193760ec5419eec9dd2b9aac", size = 15868561, upload-time = "2025-06-17T23:12:18.189Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/96/53928ad62ecddbf76f4c413025fdeab5a90adf7fbd970d800162399e504a/jax_cuda12_plugin-0.6.2-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:db4c6103c912d8cd1adf94c34d313bb4760ca7f01c897ca7cd62e65f27994199", size = 15876276, upload-time = "2025-06-17T23:12:20.361Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/f1c1790d77ccad3587e6c97045b567006a8050fec151581d4cf883779e25/jax_cuda12_plugin-0.6.2-cp313-cp313t-manylinux2014_aarch64.whl", hash = "sha256:ed5316ca1818db7ef53230ee0a41398d3a60942e361dfb857a952eb4d92fc8d7", size = 15964355, upload-time = "2025-06-17T23:12:22.176Z" },
+    { url = "https://files.pythonhosted.org/packages/07/af/c3224aafbc1d2d7654359a5410319bf15361067635bd3616cf5ad3e16af2/jax_cuda12_plugin-0.6.2-cp313-cp313t-manylinux2014_x86_64.whl", hash = "sha256:83345f52f610cdb8e90044566d8e120864150b8090968c8ab6dd8e0bfb9a6a9f", size = 16037754, upload-time = "2025-06-17T23:12:24.066Z" },
+]
+
+[package.optional-dependencies]
+with-cuda = [
+    { name = "nvidia-cublas-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-cudnn-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-cufft-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-cusolver-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-cusparse-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version < '3.11'" },
+    { name = "nvidia-nvshmem-cu12", marker = "python_full_version < '3.11'" },
+]
+
+[[package]]
+name = "jax-cuda12-plugin"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "jax-cuda12-pjrt", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/de/8294a939e9eddcf6420d568713ca5018167f15f776e125f4205d4ffd8f6f/jax_cuda12_plugin-0.9.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:b3955f375d17902f0d27e7059672cd1963a55345953a42699e4e078cec725adc", size = 5652929, upload-time = "2026-03-18T23:26:12.277Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/4769b648ff21062150a917b6b00c35825ef65a0c9faeb4630377a35c934a/jax_cuda12_plugin-0.9.2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:d5577cd867bd9267769e453bad850d4807a84396bc976f632a515edbd77e484b", size = 5659276, upload-time = "2026-03-18T23:26:13.757Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/01/cade011143cdbec397d5e78ebea84668884b2c41a52907b73ede506f520e/jax_cuda12_plugin-0.9.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:b28ccf05bcc0bc7ccbcbd326d802846574cf6da039158e76147bd96f5c6f1189", size = 5647540, upload-time = "2026-03-18T23:26:15.101Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/32/233dc2884eadf2793f885b223524275b9a19d1bfc40da51c21dce2fed485/jax_cuda12_plugin-0.9.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:88a55908d775b06dda92a8c4f4c015778e25ba5c3605b57f84b00052f66e8ef1", size = 5656514, upload-time = "2026-03-18T23:26:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6b/c5cc0d74aa2f191e0ac79c94465200ebe472b051b85ee2ca772d05632325/jax_cuda12_plugin-0.9.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:b9a27085d893cc59c2b286b1789755f91cf3eab1dea1b5be9e632f4c9739a20e", size = 5647616, upload-time = "2026-03-18T23:26:18.025Z" },
+    { url = "https://files.pythonhosted.org/packages/43/66/b459d8a8eb7ab7193f28141a5efcd904438d488d45d42c4820cf5e4893e2/jax_cuda12_plugin-0.9.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:bd7dfed17bfa9d0e3016f8c2a6767c7479d91e1bdfdf7916eb2b07435cc4658e", size = 5656184, upload-time = "2026-03-18T23:26:19.375Z" },
+    { url = "https://files.pythonhosted.org/packages/54/11/b6af77063972db08317fa3ba55094ca0b3fddd45395e3312acc5a9b64a51/jax_cuda12_plugin-0.9.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:8965073b811dbf2ea7ce11612c845498d0e900089c86dcca21219ae7b8f7996e", size = 5662366, upload-time = "2026-03-18T23:26:20.618Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/cf/6c747f6d7a2a8ac0dcd8998c29cf795e048d9e660c42dc41604be985b098/jax_cuda12_plugin-0.9.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:e03fba42374a469f856b236db65727a15923efe6778128feedfc5497aded85e7", size = 5666293, upload-time = "2026-03-18T23:26:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/79/25/f9455a5b561704078d19735317879cad063cb32f33e81e17947f6d690605/jax_cuda12_plugin-0.9.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:33212699e1bbb1bed5d2ae14ae9ff72a1eed2d092a51e6abcc0278a6b2b82874", size = 5648216, upload-time = "2026-03-18T23:26:23.82Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a4/b5f7b7e1d1f6c50a1746068daf6b4302ccaf0dfe8b5f3d120c3c06cbca58/jax_cuda12_plugin-0.9.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:5351742c0fcb21da9e094a1965ab20fde525862877f76918a490b1b56664d53a", size = 5657732, upload-time = "2026-03-18T23:26:25.184Z" },
+    { url = "https://files.pythonhosted.org/packages/23/af/dd800242f853aa3cd89d37ec56cf31330288b431c04fecb94b3bcfbfe6bd/jax_cuda12_plugin-0.9.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:918af0e625be922b1da105993f21482add3fad392a6b621d88b58557fa84090d", size = 5662507, upload-time = "2026-03-18T23:26:26.481Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5b/063f33441a34afe8c04c27fdfc1a8a240fcae11fb561476bc690f5108584/jax_cuda12_plugin-0.9.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:cd9a18876f900535c63244cb072944076a39526587582f78de333502135dd42a", size = 5666893, upload-time = "2026-03-18T23:26:28.123Z" },
+]
+
+[package.optional-dependencies]
+with-cuda = [
+    { name = "nvidia-cublas-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "jax-cuda13-pjrt"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/12/a1ea75d66fce346298638188696a9d9fb1f5d1541ec6c67a5bd5746ce87b/jax_cuda13_pjrt-0.9.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:50ea9dcbb66c3bd884686782035e95affe3a08c694c7ba43f64f3a6f78773257", size = 109099455, upload-time = "2026-03-18T23:26:30.443Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ea/c862ab5b5aae56c09d79af4f5d2829d90fad6f700a48d2a08add5d040be4/jax_cuda13_pjrt-0.9.2-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b1b0455cf6bdaa3aee51304a656b586389e6102b2d741fa54ccd124a899abb7d", size = 115087575, upload-time = "2026-03-18T23:26:34.654Z" },
+]
+
+[[package]]
+name = "jax-cuda13-plugin"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax-cuda13-pjrt", marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/157b6cd4badf957c43d913f58676d98dc936d643eff4ac28e030c317f44c/jax_cuda13_plugin-0.9.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:f0cda88f70db5877d2bb2f99c456d34e2c904da2a0f783973d4cebdad4ed0c88", size = 5642490, upload-time = "2026-03-18T23:26:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2a/7432f92e4591ee2aefb93a348dccd6aed95ae7ab3186c9d0b0325f54c81c/jax_cuda13_plugin-0.9.2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:f8d2ea568840f6b76b3a091347bd048117b45c4c985667b8172b060d1ccfcaa7", size = 5644987, upload-time = "2026-03-18T23:26:39.33Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/bc/d5c80b2e073e9d4a89b4f1de80e2c66829d471165c252b68cef31ccd9539/jax_cuda13_plugin-0.9.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:00e1a218ae3443cb93cd3cc69df3eb85b8d9180761a13628f2d07a2f52dea3c5", size = 5637141, upload-time = "2026-03-18T23:26:40.858Z" },
+    { url = "https://files.pythonhosted.org/packages/18/4a/0fc4bde105699a530893e45475a3885b41d401484a53dd32a6b2f96d1edc/jax_cuda13_plugin-0.9.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:c9c1462658c468a407db1044cbb2a799bf5c7191766620022a91e650bcc01336", size = 5642400, upload-time = "2026-03-18T23:26:42.454Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a1/109f0c8bf652dad9417e8342f89849fa3a42562a7006f5fdfea97daafccf/jax_cuda13_plugin-0.9.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:b8bd1ad3049cd7aea40c2885699f6ad7e9af17151fa3b13d12858f79513fcf00", size = 5637491, upload-time = "2026-03-18T23:26:43.786Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/d1c529abc02b094ec9a118613345c2781a9bcc1307a47a1b1aa0204bc968/jax_cuda13_plugin-0.9.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:0092a2ef890ca115eb713febb7aeb69510c9bfb96efdf65ded293c15765e5881", size = 5642085, upload-time = "2026-03-18T23:26:45.387Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fe/31319b2defb353adacb3210c25a01f2a252eb29cd07eef43895152bcff7c/jax_cuda13_plugin-0.9.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:6210f028be3579e1bbe2baef41f094230229a14fedc9d63a945fa8d19d4d60ac", size = 5651737, upload-time = "2026-03-18T23:26:46.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/16/1e31bcba3686822292c0926fc32d47bbdb7806021c0fd1048346eb8815e7/jax_cuda13_plugin-0.9.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:62fbd76e229af83cdb2e845d4f598ba9e03363c342ffabe46b0165eb4c2de9e8", size = 5652072, upload-time = "2026-03-18T23:26:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/48/831cecec9add9569b3241f2240ffe070063c48a53c526368c067cb23781d/jax_cuda13_plugin-0.9.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:9ea4c378bd4ff9a15927b518dd383a3c8721d7079a40f59f2a51fc3031e17a5b", size = 5637925, upload-time = "2026-03-18T23:26:49.276Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b7/91d8378c3fb5b474956603ab8351740a2fd8799332ebdcf62aa5e5847ed5/jax_cuda13_plugin-0.9.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:5ed2f92d6875b5a66da63d97cd80c7727fe8e12038bfd5f8777cdbb8cb0601e6", size = 5643501, upload-time = "2026-03-18T23:26:50.724Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/32/1280771c04e075e9fa9c532bb5fdbef9fdf53f879bae3f2a11bd6488e973/jax_cuda13_plugin-0.9.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:79be5ce66fd1ad3a58ece7ae90371c3ebebc8e468a76ae1b8d8730e65d301585", size = 5652313, upload-time = "2026-03-18T23:26:51.991Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b2/d29a66d1448a9b2ed56de72c94848e758ddf9d43c8e72f910ce775f3aa4c/jax_cuda13_plugin-0.9.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:73bacf855fb257ea19c52dc4b85f1a6e69bb7f0dea7bf3a0c45af536159ab262", size = 5652377, upload-time = "2026-03-18T23:26:53.54Z" },
+]
+
+[package.optional-dependencies]
+with-cuda = [
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
+    { name = "nvidia-nvvm", marker = "python_full_version >= '3.11'" },
 ]
 
 [[package]]
@@ -2125,12 +2297,78 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas-cu12"
+version = "12.9.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e2/fc9a0e985249d873150276d5afb02e39a66817fedbf1a385724393e505ed/nvidia_cublas_cu12-12.9.2.10-py3-none-win_amd64.whl", hash = "sha256:623f43027d40d44ceadf0043f002bd25cf353e8f13ce90b9a87057019f560661", size = 553162896, upload-time = "2026-04-08T18:53:10.035Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cccl-cu12"
+version = "12.9.27"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/7e/82e49956b046bdc506c789235c587d9b3ef58b8bc1782258c1e247229647/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7898b38aa68beaa234d48f0868273702342a196d6e2e9d0ef058dca2390ebea", size = 3152245, upload-time = "2025-05-01T19:32:04.802Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37869e17ce2e1ecec6eddf1927cca0f8c34e64fd848d40453df559091e2d7117", size = 3152243, upload-time = "2025-05-01T19:32:13.955Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9b/1daf405620c7ac371b76b823c6336dd742673d41a150d9a04eec2c690379/nvidia_cuda_cccl_cu12-12.9.27-py3-none-win_amd64.whl", hash = "sha256:72106f95a9bb3be18472806b4f663ebf0f9248a86d14b4ae3305725b855d9d92", size = 3152175, upload-time = "2025-05-01T19:45:11.372Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-crt"
+version = "13.2.78"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8a/3954a429bbe1dea60c7e3fa4a0cf6a4fdb7df295b2cfb49a77a73bcd3ca4/nvidia_cuda_crt-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f5f1d7bf8a89e98f19f45a2f18bb5df99a806433bfb6f0bc487d9e8f4b3677b", size = 133298, upload-time = "2026-04-13T09:37:06.368Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/78/501eee5cce9202fba2f3476529e296a7f6d003261d80b52ab0abfa09ddd6/nvidia_cuda_crt-13.2.78-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2c8615ee30ed466cb6298ecb8ffe9e6ea8b252ca833206152d155750bf831608", size = 133301, upload-time = "2026-04-13T09:37:36.922Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-cupti"
 version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/78/351b5c8cdbd9a6b4fb0d6ee73fb176dcdc1b6b6ad47c2ffff5ae8ca4a1f7/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe", size = 10077166, upload-time = "2025-06-05T20:01:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f", size = 10814997, upload-time = "2025-06-05T20:01:10.168Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b4/298983ab1a83de500f77d0add86d16d63b19d1a82c59f8eaf04f90445703/nvidia_cuda_cupti_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:1848a9380067560d5bee10ed240eecc22991713e672c0515f9c3d9396adf93c8", size = 7730496, upload-time = "2025-06-05T20:11:26.444Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvcc"
+version = "13.2.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-crt", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cuda-runtime", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-nvvm", marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/df/faf551572ae1359290afa5cb05d2c4b7e6674b07b8283b20eab4dbad15f6/nvidia_cuda_nvcc-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dfc76950c775cd00ce588f15192f08c9b858c0dcfa7da685acf39a3d0d8f588b", size = 38713559, upload-time = "2026-04-13T09:42:17.478Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0f/c7c7d538c61794130e759ad74710ab5aa8cab1f700ee1754381f8c665605/nvidia_cuda_nvcc-13.2.78-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c3bd144dd9b6b25e062589acb7bbd43d93d3120c72fad71da808f9817aba1239", size = 44040318, upload-time = "2026-04-13T09:42:50.457Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvcc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:5d6a0d32fdc7ea39917c20065614ae93add6f577d840233237ff08e9a38f58f0", size = 40546229, upload-time = "2025-06-05T20:01:53.357Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/8cc072436787104bbbcbde1f76ab4a0d89e68f7cebc758dd2ad7913a43d0/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44e1eca4d08926193a558d2434b1bf83d57b4d5743e0c431c0c83d51da1df62b", size = 39411138, upload-time = "2025-06-05T20:01:43.182Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/9e/c71c53655a65d7531c89421c282359e2f626838762f1ce6180ea0bbebd29/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:8ed7f0b17dea662755395be029376db3b94fed5cbb17c2d35cc866c5b1b84099", size = 34669845, upload-time = "2025-06-05T20:11:56.308Z" },
 ]
 
 [[package]]
@@ -2143,12 +2381,45 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-runtime"
 version = "13.0.96"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891", size = 3591604, upload-time = "2025-06-05T20:11:17.036Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.22.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/ff/c6a098c1e0bccc68aac5f1684526cf8936abb7024dcc46dca315b8a6f47f/nvidia_cudnn_cu12-9.22.0.52-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:cd9011812498376f866b9826331cc965ac922eb2df8549c9f2989f10255e5001", size = 774536507, upload-time = "2026-05-08T15:36:09.067Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8f/2ede6b758b7524608472010f632bdd3370ea271d715d1d66044614b84cdc/nvidia_cudnn_cu12-9.22.0.52-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:391b9a7ee6386daaca7f8dca41e83c2c99f760c9581a0400755e87b4287b8847", size = 718382818, upload-time = "2026-05-08T15:37:38.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a4/045f8d0ce6b99726d88e76bbb8ee147123f55e80111d89262762d8149abb/nvidia_cudnn_cu12-9.22.0.52-py3-none-win_amd64.whl", hash = "sha256:5d10117314c861245992dbcf8a6f8ae1f54852137a7c9f80cc9de9fa596f7d62", size = 687235974, upload-time = "2026-05-08T15:39:37.967Z" },
 ]
 
 [[package]]
@@ -2173,6 +2444,19 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.4.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ee/29955203338515b940bd4f60ffdbc073428f25ef9bfbce44c9a066aedc5c/nvidia_cufft_cu12-11.4.1.4-py3-none-win_amd64.whl", hash = "sha256:8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80", size = 200067309, upload-time = "2025-06-05T20:13:59.762Z" },
 ]
 
 [[package]]
@@ -2208,6 +2492,21 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.5.82"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
+    { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5d/feb7f86b809f89b14193beffebe24cf2e4bf7af08372ab8cdd34d19a65a0/nvidia_cusolver_cu12-11.7.5.82-py3-none-win_amd64.whl", hash = "sha256:77666337237716783c6269a658dea310195cddbd80a5b2919b1ba8735cec8efd", size = 326215953, upload-time = "2025-06-05T20:14:41.76Z" },
+]
+
+[[package]]
 name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2220,12 +2519,34 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.10.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78", size = 366465088, upload-time = "2025-06-05T20:08:20.413Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ef/063500c25670fbd1cbb0cd3eb7c8a061585b53adb4dd8bf3492bb49b0df3/nvidia_cusparse_cu12-12.5.10.65-py3-none-win_amd64.whl", hash = "sha256:9e487468a22a1eaf1fbd1d2035936a905feb79c4ce5c2f67626764ee4f90227c", size = 362504719, upload-time = "2025-06-05T20:15:17.947Z" },
+]
+
+[[package]]
 name = "nvidia-cusparselt-cu13"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
     { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.30.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/2b/1757b6b74ee241de5efee3f35487dcb33e09c07605254809c6ce36aeb783/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:606fa9aa9215c00367d060188eb1a5bbd28396aff5e11b9200d99d1a6ab79a71", size = 300091935, upload-time = "2026-04-23T03:22:58.024Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c3/0e45ff4dce8401f6ea7c25d80d75738813a47f5ae2691e2478f2fd1e5e93/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:040974b261edec4b8b793e59e92ab7176fe4ab4bc61b800f9f3bfaeec2d436f3", size = 300164158, upload-time = "2026-04-23T03:23:19.589Z" },
 ]
 
 [[package]]
@@ -2247,6 +2568,28 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db", size = 35584936, upload-time = "2025-06-05T20:16:08.525Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-cccl-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/da/bd8ae5201f8c5751ece31fe4fe489ece10fbcf5fcc1a595855b6459b6d6e/nvidia_nvshmem_cu12-3.6.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7b38521ff84cdfc68da3360fe249cfbabfe05ee9aa271458857476124b03a420", size = 153109548, upload-time = "2026-03-24T19:19:19.523Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/da/36fa8307cc40889307fed415d70b67d35ec330ffce889a9c03cf8f616cfa/nvidia_nvshmem_cu12-3.6.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f86db35f1ced21a790fa255dcae7db8998bf8655a95e76c033a6574190b398e4", size = 153270920, upload-time = "2026-03-24T19:19:42.626Z" },
+]
+
+[[package]]
 name = "nvidia-nvshmem-cu13"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2262,6 +2605,16 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "nvidia-nvvm"
+version = "13.2.78"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/1f/930d63ccc8adcdf27bfc051a24e3e4da2cf6ef987848d6d1d642e29d704b/nvidia_nvvm-13.2.78-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:f5aa433631109bbdec81802c5b5f319bf10bc891fe2f212e4e445845211d6f77", size = 64279462, upload-time = "2026-04-13T10:02:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/fd/db44b7a662a6af75a9a0683ca4580c855a3f5fcfdf1261b0ddb9fce0ee26/nvidia_nvvm-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88075f87a361a1dce95c799cabc028f7093af616a5702dcfb74eba4045dbbd5f", size = 61886055, upload-time = "2026-04-13T10:02:00.345Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b9/c3862fd1073326c61233f05e816c17a28ab86a361db1b7561c7f33ac3af4/nvidia_nvvm-13.2.78-py3-none-win_amd64.whl", hash = "sha256:cf8e91654e74285e9c574b3a45b92928c0a6d135928906cf11ce470bbec6a8ec", size = 56752219, upload-time = "2026-04-13T10:15:11.102Z" },
 ]
 
 [[package]]
@@ -2519,8 +2872,11 @@ dependencies = [
 
 [package.optional-dependencies]
 cuda12 = [
-    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jax", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version < '3.11'" },
+    { name = "jax", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version >= '3.11'" },
+]
+cuda13 = [
+    { name = "jax", version = "0.9.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda13"], marker = "python_full_version >= '3.11'" },
 ]
 dev = [
     { name = "basedpyright" },
@@ -2557,7 +2913,8 @@ requires-dist = [
     { name = "h5py", specifier = ">=3.13.0" },
     { name = "imageio", specifier = ">=2.37.0" },
     { name = "jax", specifier = ">=0.6.2" },
-    { name = "jax", extras = ["cuda12-pip"], marker = "extra == 'cuda12'", specifier = ">=0.6.2" },
+    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.6.2" },
+    { name = "jax", extras = ["cuda13"], marker = "python_full_version >= '3.11' and extra == 'cuda13'", specifier = ">=0.7.1" },
     { name = "jaxopt", specifier = ">=0.8.5" },
     { name = "jaxtyping", specifier = ">=0.3.7" },
     { name = "matplotlib", specifier = ">=3.10.1" },
@@ -2573,7 +2930,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "wandb", specifier = ">=0.20.1" },
 ]
-provides-extras = ["dev", "cuda12"]
+provides-extras = ["dev", "cuda12", "cuda13"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Addresses every review comment on #129 (`dev → main` release PR) so the release can proceed. Targets `dev`; once merged, #129 reflects the fixes.

## Code

- **`yraw` → `y_raw`** everywhere (antonioterpin, affine_inequality.py): consistent with `y_star`. 0 occurrences of `yraw` left.
- **`dyn` → `mat`** swept case-by-case (p-grontas + antonioterpin): `a_dyn_aug`→`a_mat_aug`, `a_dyn_aug_inv`→`a_mat_aug_inv`, `a_dyn_lifted`→`a_mat_lifted`, `a_dyn_new`→`a_mat_new`. Only legitimate "dynamics" prose and the documented legacy `a_dyn` loader fallback remain.
- **`Aop` → `a_mat_op`** in toy_SOC/main.py (p-grontas).
- **`zip(..., strict=False)` → `strict=True`** everywhere (p-grontas; antonioterpin "here and likely everywhere we have zip"). No `strict=False` left.
- **`box_mask` → `mask_box`** everywhere (antonioterpin, naming.md): aligns with the `mask_*` convention.
- **toy_SOC hyperparameters** consolidated into a single typed `HYPERPARAMETERS` block at the top of the file, incl. the previously-stray validation batch size (p-grontas). Used a typed dict rather than YAML — keeps the script self-contained with no extra I/O/dependency and is type-checked (re: antonioterpin "use a yaml?").
- **project.py comments**: "constraint is active" → "constraint is present"; the `is_single_simple_constraint` comment now correctly states it is "exactly one of an equality or a box constraint" (p-grontas; code was already correct).

## Tests

- **test_abstract_constraint.py**: `_make_nl_parameter_carrier` helper → `@pytest.fixture` (p-grontas).
- **test_equilibration.py**: loss closure now uses typed `LossInputs`/`LossOptions` dataclasses with full docstrings + annotations (p-grontas readability).

## Docs

- **PiNet → Pinet** normalized repo-wide (p-grontas); 0 "PiNet" left.
- **naming.md**: "Flag (is per-instance)" → "Is per-instance"; the unmaintainable per-spec attribute table removed (antonioterpin).
- **testing.md**: reconciled with reality — flat `src/test/` layout acknowledged, tree-reorg tracked in #130, legacy large files noted; module-docstring + basedpyright claims verified true.
- **docs/index.md**: standards/workflows/agents tables cross-checked against the filesystem (all map 1:1); stale testing.md row description corrected.
- **.github/copilot-instructions.md** created so the Copilot entry point in agent-development.md is real, not aspirational (p-grontas).
- **CONTRIBUTING.md** rewritten for the current `uv`/`docs/` setup (p-grontas review blocker).

## GitHub issues (from review comments on data/tooling)

- **#46** updated: benchmark datasets → Hugging Face Hub decision recorded (antonioterpin).
- **#131 / #132 / #133** filed from the tinyros SWE-practice review comment: PyPI release on tag (OIDC), Dependabot autoupdate, and CI hardening (audit/CodeQL/scheduled benchmarks/repo-hygiene). All cross-checked against actual `antonioterpin/tinyros` files.

## Validation

- `uv run pre-commit run --all-files` ✓ (ruff, ruff format, pydoclint, basedpyright)
- `uv run pre-commit run --hook-stage push --all-files` ✓ (strict basedpyright, src/ + tests/)
- `uv run pytest` → **603 passed**
- `uv run pytest -m benchmark` → **6 passed** (golden metrics intact after the loader renames)

Note: this does not touch the #115 workstation-reproduction / determinism blocker, which is a separate manual exit criterion on #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)