### PR TITLE
chore(ci): add PyPI release workflow (OIDC trusted publishing)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write # gh release create
+  id-token: write # PyPI OIDC trusted publishing
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Scope the OIDC token to the `pypi` GitHub environment so the PyPI
+    # trusted-publisher claim can pin to it. Configure the environment +
+    # the matching trusted publisher on PyPI before the first release.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pinet-hcnn
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history -> previous-tag lookup
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          TAG_VERSION="${TAG#v}"
+          PYPROJECT_VERSION=$(
+            awk -F'"' '/^version = /{print $2; exit}' pyproject.toml
+          )
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::Tag $TAG ($TAG_VERSION) does not match pyproject.toml version ($PYPROJECT_VERSION)"
+            exit 1
+          fi
+          echo "Tag $TAG matches pyproject.toml version $PYPROJECT_VERSION"
+
+      - name: Build distribution
+        run: uv build
+
+      - name: Verify metadata with twine
+        run: uv run --with twine twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          PREV_TAG=$(
+            git tag --sort=-v:refname \
+              | grep -A1 "^${TAG}$" \
+              | tail -n1
+          )
+          if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes \
+              --notes-start-tag "$PREV_TAG"
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes
+          fi


### PR DESCRIPTION
## TL;DR
- Adds `.github/workflows/release.yaml` (tag-triggered) that builds, validates, and publishes `pinet-hcnn` to PyPI via OIDC trusted publishing, then cuts a GitHub Release. Adapted from `antonioterpin/tinyros`.

## Highlights
- Triggers on `v*` tags.
- Verifies the tag matches `pyproject.toml`'s `version` (fails otherwise).
- `uv build` → `twine check` → publish via `pypa/gh-action-pypi-publish` (no long-lived token), scoped to a `pypi` GitHub Environment.
- Creates a GitHub Release with auto-generated notes.

## Prerequisite (before first tagged release)
- Configure the `pypi` GitHub Environment and the matching PyPI trusted publisher for the `pinet-hcnn` project.

## Tests
- Verified locally: `uv build` and `twine check dist/*` succeed; version-extraction reads `0.1.0` from `pyproject.toml`. The workflow itself only runs on tags, so it does not run on this PR.

## Related
- Closes #131