### PR TITLE
chore(ci): add Dependabot for deps and Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## TL;DR
- Adds `.github/dependabot.yml` with weekly update PRs for the `github-actions` and `pip` ecosystems. Mirrors `antonioterpin/tinyros`.

## Highlights
- `github-actions` (dir `/`, weekly, limit 5).
- `pip` (dir `/`, weekly, limit 5).

## Notes
- The project uses `uv.lock`; Dependabot's `pip` ecosystem opens PRs against `pyproject.toml` and may need a `uv lock` refresh on those PRs until uv-native support lands.

## Related
- Closes #132