### PR TITLE
chore(ci): harden CI (audit, CodeQL, benchmarks, hygiene)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo. Add more specific entries
+# above this line if/when sub-areas get dedicated reviewers.
+* @antonioterpin

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,85 @@
+<!--
+Be synthetic: bullet points are preferred and 1–3 short sentences per section.
+Delete any guidance comments before submitting.
+-->
+
+## TL;DR
+<!-- What does this PR do, in one or two sentences? -->
+- Short summary: ...
+
+## Breaking Changes
+<!-- List anything that requires user action or could break existing behavior. Link to migration steps. -->
+- No breaking changes.
+<!-- If any:
+- [ ] ... (describe)
+- Migration notes: ...
+-->
+
+## Highlights
+<!-- Top 3–6 notable changes, user-visible first. Keep each to one line. -->
+- ...
+
+## Examples / Demos
+<!-- Minimal examples, commands, or screenshots/gifs. Prefer concrete inputs/outputs. -->
+- Example command: `...`
+- Output: `...`
+- Screenshots: (optional) ...
+
+## Why
+<!-- The rationale/problem this solves. 1–3 sentences. -->
+- ...
+
+## How
+<!-- Brief approach/implementation notes. Keep it high-level; link to code as needed. -->
+- ...
+
+## Tests
+<!-- What’s covered? How to run them? -->
+- Added/updated tests: ...
+- How to run: `uv run pytest -k ...`
+- Current status: all passing / flaky test noted in ...
+
+## Documentation
+<!-- User docs, README, changelog. -->
+- Docs updated: yes/no (link: ...)
+- Changelog entry: added/not needed
+
+## Performance
+<!-- Any perf impact or measurements. -->
+- No significant performance impact.
+<!-- If applicable:
+- Benchmark: before ... / after ...
+-->
+
+## Compatibility
+<!-- Supported versions, APIs, platforms affected. -->
+- No compatibility issues identified.
+
+## Migration Steps (if any)
+<!-- Only needed if there are breaking changes. -->
+- Not applicable.
+
+## Rollback Plan
+<!-- How to safely revert if things go wrong. -->
+- Revert via `git revert <sha>`; no data migration required.
+<!-- If data/schema changes:
+- Provide rollback script/steps: ...
+-->
+
+## Related
+<!-- Link issues, PRs, design docs, tickets. -->
+- Closes #...
+- Relates to #...
+
+## Checklist
+Before submitting the PR, make sure to check every entry of the following checklist (`[x]`), or move them to N/A.
+
+#### Done:
+- [ ] Tests added/updated
+- [ ] Docs updated (README/CHANGELOG)
+- [ ] Backwards compatible (or migration steps provided)
+- [ ] Self-reviewed and linted
+- [ ] Examples/screenshots/recordings for usage changes
+
+#### N/A:
+- None

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,34 @@
+name: Dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 1' # Monday 07:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+
+      - name: Export runtime dependency tree
+        run: |
+          uv export --no-hashes --no-dev \
+            --format requirements-txt \
+            > /tmp/runtime-requirements.txt
+
+      - name: Run pip-audit
+        run: uvx pip-audit --requirement /tmp/runtime-requirements.txt

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,35 @@
+name: Benchmarks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 0' # Sunday 05:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      # The heavier end-to-end benchmark smoke tests are marked
+      # ``@pytest.mark.benchmark`` and opted out of by default via
+      # ``pytest.ini`` (``-m "not benchmark"``). Run them explicitly here to
+      # catch bitrot in the benchmark code paths (data loaders, model setup,
+      # a few projection/training steps). Tests skip gracefully when the
+      # in-repo datasets are absent, so this stays green on a clean runner.
+      - name: Run benchmarks
+        run: uv run pytest -m benchmark

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1' # Monday 06:00 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Perform analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:python"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | yes       |
+| < 0.1   | no        |
+
+Only the latest released minor line of `pinet-hcnn` receives security
+fixes. Update this table when the release version changes.
+
+## Reporting a vulnerability
+
+Please report security issues privately to **antonio.terpin@gmail.com**.
+
+Include where possible:
+
+- a minimal reproduction (inputs / constraint specification and the
+  sequence of calls);
+- the `pinet-hcnn` version (`pip show pinet-hcnn`) and the JAX / jaxlib
+  versions;
+- whether a CPU-only or GPU (CUDA) backend is required to trigger it.
+
+The maintainer will acknowledge receipt within 7 days and aim to ship a
+fix and a coordinated disclosure within 30 days for confirmed issues.
+Public discussion happens after a fix is released.
+
+## Scope
+
+pinet is a numerical library (a JAX output layer that projects onto convex
+constraint sets). It exposes no network services and opens no sockets, so
+the attack surface is small:
+
+- **Dependencies.** The most likely source of a security issue is a
+  vulnerable transitive dependency. These are monitored by the scheduled
+  `pip-audit` workflow and bumped via Dependabot; reports of an unpatched
+  advisory affecting the runtime tree are in scope.
+- **Untrusted artifacts.** Loading untrusted datasets, model checkpoints,
+  or pickled objects (e.g. via `h5py`, `torch`, or `wandb`) inherits the
+  security properties of those libraries and is the caller's
+  responsibility — it is outside this policy unless pinet itself
+  mishandles the data in a way that escalates beyond the underlying loader.
+- **Numerical behavior.** Incorrect or non-converging projections are
+  correctness bugs, not security vulnerabilities; please file them as
+  regular issues.
+
+Crashes or memory-safety problems reachable purely through pinet's public
+Python API with well-formed array inputs are in scope.


### PR DESCRIPTION
## TL;DR
- Closes the remaining CI/SWE-practice gaps vs `antonioterpin/tinyros`: dependency audit, CodeQL, scheduled benchmarks, and repo-hygiene files.

## Highlights
- **audit.yaml** — scheduled `pip-audit` over the exported runtime dependency tree (push/PR on `main` + weekly cron).
- **codeql.yaml** — `github/codeql-action` with `security-extended` (push/PR on `main` + weekly cron).
- **benchmarks.yaml** — `workflow_dispatch` + weekly cron running the `@pytest.mark.benchmark` suite to catch bitrot; tests skip gracefully when datasets are absent.
- **Hygiene** — `.github/CODEOWNERS`, `.github/pull_request_template.md`, and a pinet-tailored `SECURITY.md` (pinet is a library with no network surface, so the threat model centers on dependencies and untrusted artifacts rather than tinyros's RPC transport).

## Tests
- Verified `uv export --no-hashes --no-dev` resolves the runtime tree and all new YAML parses. The new workflows trigger on `main`/tags/cron, so they don't run on this PR into `dev`.

## Notes
- `SECURITY.md` supported-versions table lists `0.1.x` (current `pyproject.toml` version); update at release if the version bumps.

## Related
- Closes #133