### PR TITLE
chore(ci): drop dead commitlint configFile reference

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -13,5 +13,3 @@ jobs:
         uses: actions/checkout@v3
       - name: Run Commitlint
         uses: wagoid/commitlint-github-action@v5
-        with:
-          configFile: commitlint.config.js


### PR DESCRIPTION
## TL;DR
- Removes the `configFile: commitlint.config.js` input from the commit-lint workflow — that file doesn't exist, and the dead reference breaks the `wagoid/commitlint-github-action` v5→v6 bump.

## Why
- `commitlint.config.js` is not in the repo; commit-lint already runs on the action's bundled `@commitlint/config-conventional` default.
- v6 of the action rejects a `.js` `configFile` extension up front (`use .mjs instead`), which is why Dependabot PR #143 fails `commit-lint`.

## How
- Drop the `with: configFile:` lines so the action uses its default config (no behavior change under v5; unblocks v6).

## Tests
- commit-lint validates this PR's own message; no code changes.

## Related
- Relates to #143