### PR TITLE
chore: sync dev -> main (drop dead commitlint configFile)

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -13,5 +13,3 @@ jobs:
         uses: actions/checkout@v3
       - name: Run Commitlint
         uses: wagoid/commitlint-github-action@v5
-        with:
-          configFile: commitlint.config.js


### PR DESCRIPTION
## TL;DR
- Syncs `dev` into `main`. The only delta is #146: removing the dead `configFile: commitlint.config.js` from the commit-lint workflow (`main` already has the Dependabot bumps and the v0.2.0 release via back-merge).

## Why
- After the Dependabot PRs merged into `main` and #146 (commitlint fix) merged into `dev`, the branches diverged. `dev` was back-merged with `main`, so this PR carries just the `configFile` removal forward.
- This also unblocks **#143** (commitlint action v5→v6): `main`'s workflow currently references a non-existent `commitlint.config.js`, which v6 rejects (`.js` not allowed). Removing the reference makes commit-lint pass under v6.

## How
- Drop the `with: configFile:` lines so commit-lint uses the action's default `@commitlint/config-conventional` (the de-facto current behavior).

## Tests
- No code changes; CI re-runs on the merge. `main` and `dev` are identical after this merges.

## Related
- Brings #146 to main; unblocks #143.