### PR TITLE
chore(ci): add commitlint config relaxing body line length

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,12 @@
+// Commitlint configuration (auto-discovered by wagoid/commitlint-github-action).
+//
+// Extends the Conventional Commits preset but relaxes body-max-line-length:
+// Dependabot's auto-generated bodies (changelog/compare URLs) and trailers
+// like Co-authored-by routinely exceed 100 columns, and wrapping URLs is not
+// useful. All other conventional rules (type-enum, subject-case, ...) stay on.
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always'],
+  },
+};


### PR DESCRIPTION
## TL;DR
- Adds an auto-discovered `commitlint.config.mjs` that extends Conventional Commits but disables `body-max-line-length`, so Dependabot's long-URL bodies pass commit-lint.

## Why
- After #146/#147 removed the dead `configFile`, commit-lint genuinely lints messages and `@commitlint/config-conventional`'s `body-max-line-length: 100` rejects Dependabot bodies (e.g. #143 has a 104-char line). This would block #143 and all future Dependabot PRs.

## How
- `commitlint.config.mjs` (auto-discovered by `wagoid/commitlint-github-action`, no workflow change) extends the conventional preset and sets `body-max-line-length: [0]`. All other rules stay on.

## Tests
- This PR's own `commit-lint` run smoke-tests that the config loads and the conventional rules still apply.

## Related
- Unblocks #143; relates to #146/#147.