### PR TITLE
chore: sync dev -> main (commitlint body-length config)

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,12 @@
+// Commitlint configuration (auto-discovered by wagoid/commitlint-github-action).
+//
+// Extends the Conventional Commits preset but relaxes body-max-line-length:
+// Dependabot's auto-generated bodies (changelog/compare URLs) and trailers
+// like Co-authored-by routinely exceed 100 columns, and wrapping URLs is not
+// useful. All other conventional rules (type-enum, subject-case, ...) stay on.
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always'],
+  },
+};


### PR DESCRIPTION
Brings commitlint.config.mjs (disables body-max-line-length) to main so Dependabot PR #143 (and future bot PRs) pass commit-lint. Relates to #143.