### PR TITLE
chore(ci): target Dependabot PRs at dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,14 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
 
   - package-ecosystem: pip
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
Adds `target-branch: dev` to both update entries in `.github/dependabot.yml` so Dependabot opens dependency PRs against `dev` instead of the default branch (`main`).

Dependabot reads its config from the default branch, so this must land on `main` to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)