### PR TITLE
chore: sync dev with main (Dependabot target + latest main)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,14 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
 
   - package-ecosystem: pip
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -12,4 +12,4 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Run Commitlint
-        uses: wagoid/commitlint-github-action@v5
+        uses: wagoid/commitlint-github-action@v6


### PR DESCRIPTION
Brings `dev` up to date with `main`, including the Dependabot `target-branch: dev` config (#152) and the latest commits on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)